### PR TITLE
adding separate consumer and corporate api docs

### DIFF
--- a/api-reference/apidocs.json
+++ b/api-reference/apidocs.json
@@ -1,0 +1,22370 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+      "title": "OrbitXPay API",
+      "version": "1.0.0",
+      "description": "\nThis API is designed for managing the functionalities of **OrbitXPay**.\n\n## Authentication\n\nThe API uses **Bearer Token** authentication. All requests to secured endpoints must include the following header:\n\n```\nAuthorization: Bearer <your-token>\n```\n\n### How to Obtain the Token\n1. Authenticate by sending a request to the **`/auth/signin-email`** OR **`/auth/signin-social`** endpoint.\n2. Upon successful authentication, you will receive a Bearer token.\n\n### Error Responses\n- **`401 Unauthorized`**: Returned if the token is missing, invalid, or expired.\n- **`403 Forbidden`**: Returned if the token does not have sufficient permissions to access the requested resource.\n\n---\n\nFor further details, refer to individual endpoints.\n"
+    },
+    "servers": [
+      {
+        "url": "https://api-qa.orbitxpay.com/api/v1",
+        "description": "API server V1"
+      }
+    ],
+    "paths": {
+      "/account": {
+        "get": {
+          "summary": "Fetch Referral code and referral count",
+          "description": "Retreive referral code and number of reffered customers\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Account Information fetched Succesfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Referral Data retreived succesfully."
+                      },
+                      "badge": {
+                        "type": "object",
+                        "description": "Badge earned by the user based on their activities in the system.",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Short code for the badge.",
+                            "example": "SupF"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Full name of the badge.",
+                            "example": "SuperFan"
+                          }
+                        }
+                      },
+                      "referralCode": {
+                        "type": "string",
+                        "example": "absdkfjhika"
+                      },
+                      "referralDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.1
+                      },
+                      "referralDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "percentage",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "referralCount": {
+                        "type": "number",
+                        "example": 62
+                      },
+                      "referralEarning": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "referrerCode": {
+                        "type": "string",
+                        "example": "absdkfjhdsd"
+                      },
+                      "referrerDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.2
+                      },
+                      "referrerDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "flat",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "totalEarning": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "totalClaimed": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "minClaimAmount": {
+                        "type": "number",
+                        "description": "In cents",
+                        "example": 50
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/account/reward/claim": {
+        "get": {
+          "summary": "Fetch all pending reward claim requests",
+          "description": "Retrieves all reward claim requests that are currently pending.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "Page number",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Number of items per page",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved all pending reward claims.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Claims retrieved successfully"
+                      },
+                      "claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 123456789
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Claim status (pending, completed).",
+                              "example": "pending"
+                            },
+                            "amount": {
+                              "type": "number",
+                              "example": 211.45
+                            },
+                            "txhash": {
+                              "type": "string",
+                              "description": "Transaction hash of the completed claim request.",
+                              "example": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb"
+                            },
+                            "createdAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-02-04T04:59:17.272Z"
+                            }
+                          }
+                        }
+                      },
+                      "totalClaims": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "totalPages": {
+                        "type": "number",
+                        "example": 10
+                      },
+                      "page": {
+                        "type": "number",
+                        "example": 2
+                      },
+                      "limit": {
+                        "type": "number",
+                        "example": 10
+                      }
+                    }
+                  },
+                  "examples": {
+                    "PendingClaim": {
+                      "summary": "Example of a pending claim",
+                      "value": {
+                        "status": "success",
+                        "message": "Claims retrieved successfully",
+                        "claims": [
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                            "status": "pending",
+                            "amount": 211.45,
+                            "txhash": "",
+                            "createdAt": "2025-02-27T11:50:40.000Z"
+                          }
+                        ],
+                        "totalClaims": 100,
+                        "totalPages": 10,
+                        "page": 2,
+                        "limit": 10
+                      }
+                    },
+                    "CompletedClaim": {
+                      "summary": "Example of a completed claim",
+                      "value": {
+                        "status": "success",
+                        "message": "Claims retrieved successfully",
+                        "claims": [
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                            "status": "completed",
+                            "amount": 211.45,
+                            "txhash": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb",
+                            "createdAt": "2025-02-27T11:50:40.000Z"
+                          }
+                        ],
+                        "totalClaims": 100,
+                        "totalPages": 10,
+                        "page": 2,
+                        "limit": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Raise a reward claim request",
+          "description": "Stores the data in the database indicating that the user's request for reward claim has been raised.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Request for reward claim has been raised successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Your reward claim request has been raised."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/account/referrer-code": {
+        "put": {
+          "summary": "Update referrer code for the customer",
+          "description": "Updates the account with a new referrer code provided by the customer.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "referrerCode": {
+                      "type": "string",
+                      "description": "Referrer code to associate with the current user",
+                      "example": "12345678"
+                    }
+                  },
+                  "required": [
+                    "referrerCode"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Referrer code updated successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Account information updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid input or validation failure",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Could not update referral code due to validation failure"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "referralCode"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Invalid referrer code, no customer found with this referral code."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "RequiredError": {
+                      "summary": "Referrer code is required",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "ReferrerCode is required"
+                          }
+                        ]
+                      }
+                    },
+                    "LengthValidationError": {
+                      "summary": "Referrer code length validation",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "Referrer code must be greater than 0 and less than 50"
+                          }
+                        ]
+                      }
+                    },
+                    "TypeValidationError": {
+                      "summary": "Referrer code type validation",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "Referrer Code must be of type string"
+                          }
+                        ]
+                      }
+                    },
+                    "NotFoundError": {
+                      "summary": "Referrer code not found",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "Invalid referrer code, no customer found with this referral code."
+                          }
+                        ]
+                      }
+                    },
+                    "ConflictWithOwnCode": {
+                      "summary": "Referrer code matches own referral code",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "Refferal Code & referrer Code cannot be same."
+                          }
+                        ]
+                      }
+                    },
+                    "AlreadySetError": {
+                      "summary": "Referrer code already set",
+                      "value": {
+                        "message": "Could not update referral code due to validation failure",
+                        "errors": [
+                          {
+                            "field": "referrerCode",
+                            "message": "Referral code is already set for this customer."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric": {
+        "get": {
+          "summary": "Get admin metrics",
+          "description": "This API returns analytics data for various widgets for the admin dashboard.\nYou can pass one or more `metric_name` query parameters to retrieve multiple widgets at once.\n",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "metric_name",
+              "in": "query",
+              "required": true,
+              "style": "form",
+              "explode": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "total_users",
+                    "total_users_registered",
+                    "total_kyc_approved",
+                    "total_active_cards",
+                    "total_live_tvl",
+                    "total_kyc_approval_rate",
+                    "total_kyc_card_activation_ratio",
+                    "total_deposit_to_spend_ratio",
+                    "financial_overview",
+                    "kyc_status",
+                    "total_deposits",
+                    "total_spent",
+                    "card_activation",
+                    "global_spend_categories",
+                    "global_spend_countries",
+                    "global_spend_merchants",
+                    "demographics_categories",
+                    "demographics_countries",
+                    "demographics_merchants",
+                    "card_product_performance"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "startDate",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "format": "date",
+                "example": "2024-01-01"
+              }
+            },
+            {
+              "name": "endDate",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "format": "date",
+                "example": "2024-04-01"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Metric widget response",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "date_range": {
+                      "start": "2024-01-01",
+                      "end": "2024-04-01"
+                    },
+                    "widget": {
+                      "total_users": {
+                        "type": "stat_card",
+                        "title": "Total Users",
+                        "value": 12000
+                      },
+                      "total_kyc_card_activation_ratio": {
+                        "type": "stat_card",
+                        "title": "KYC Card Activation Ratio",
+                        "value": "75.0"
+                      },
+                      "total_deposit_to_spend_ratio": {
+                        "type": "stat_card",
+                        "title": "Deposit to Spend Ratio",
+                        "value": "1:2"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/users": {
+        "get": {
+          "summary": "Get paginated user metrics",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "sortBy",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "sortOrder",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of users with status and registration details",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "total": 2,
+                    "users": [
+                      {
+                        "name": "John Doe",
+                        "createdAt": "2024-01-15T10:00:00.000Z",
+                        "mobile": "9876543210",
+                        "email": "john@example.com",
+                        "status": "active"
+                      },
+                      {
+                        "name": "Jane Smith",
+                        "createdAt": "2024-01-17T10:00:00.000Z",
+                        "mobile": "9123456780",
+                        "email": "jane@example.com",
+                        "status": "inactive"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/users/{userId}": {
+        "get": {
+          "summary": "Get user metrics by ID",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User account summary and personal info",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "personalInfo": {
+                      "name": "John Doe",
+                      "createdAt": "2024-01-10T00:00:00.000Z",
+                      "email": "john@example.com",
+                      "phone": "9876543210",
+                      "country": "India"
+                    },
+                    "accountSummary": {
+                      "currentBalance": 12000,
+                      "totalCards": 3,
+                      "aciveCards": 2,
+                      "totalDeposited": 50000,
+                      "toalSpent": 38000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/users/{userId}/kyc-flow": {
+        "get": {
+          "summary": "Get user KYC flow details",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "KYC timeline including verifications and actions",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "mobileVerified": "2023-01-01",
+                    "emailVerified": "2023-01-01",
+                    "kycSubmitted": "2023-01-05",
+                    "kycVerified": "2023-01-10",
+                    "addedCard": "2023-01-15",
+                    "firstDeposit": "2023-01-20",
+                    "firstSpend": "2023-01-25"
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/users/{userId}/transactions": {
+        "get": {
+          "summary": "Get transactions for a user",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            },
+            {
+              "name": "sortBy",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "sortOrder",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
+              }
+            },
+            {
+              "name": "cardFilter",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of transactions made by the user",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "total": 1,
+                    "transactions": [
+                      {
+                        "merchantName": "Amazon",
+                        "cardNumber": "XXXX-XXXX-XXXX-1234",
+                        "transactionType": "debit",
+                        "createdAt": "2024-04-01T12:00:00.000Z",
+                        "amount": 2500,
+                        "status": "completed"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/forgot-password": {
+        "post": {
+          "summary": "Send forgot password link to admin",
+          "description": "Sends a password reset email to the admin if the email is valid and associated with a partner.",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "example": "admin@example.com"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset link sent successfully",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "success": true,
+                    "message": "Password reset link sent successfully."
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Validation errors",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "message": "Validation failed for forgot password request",
+                    "errors": [
+                      {
+                        "property": "email",
+                        "constraints": {
+                          "valid": "Invalid email address."
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/admin-metric/reset-password": {
+        "put": {
+          "summary": "Reset admin password",
+          "description": "Resets the password for an admin using a verified reset token or trusted context.",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "password": {
+                      "type": "string",
+                      "example": "NewSecurePassword123!"
+                    },
+                    "confirmPassword": {
+                      "type": "string",
+                      "example": "NewSecurePassword123!"
+                    }
+                  },
+                  "required": [
+                    "password",
+                    "confirmPassword"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset successfully",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "success": true,
+                    "message": "Password reset successfully"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Validation errors",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "message": "Unable to reset password due to validation failures",
+                    "errors": [
+                      {
+                        "property": "confirmPassword",
+                        "constraints": {
+                          "match": "Passwords do not match"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/users/{userId}/cards": {
+        "get": {
+          "summary": "Get summary of all cards for a user",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            },
+            {
+              "name": "filter",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Cards owned by user with spend data",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "totalCards": 3,
+                    "cards": [
+                      {
+                        "imgUrl": "https://example.com/card.png",
+                        "name": "Premium Card",
+                        "last4digits": "1234",
+                        "cardType": "credit",
+                        "totalSpent": 120000,
+                        "status": "active"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/cards": {
+        "get": {
+          "summary": "Get list of card products with fee and description",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "filter",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of available card products",
+              "content": {
+                "application/json": {
+                  "example": [
+                    {
+                      "name": "Gold Card",
+                      "description": "Best for shopping",
+                      "fee": {
+                        "yearly": 999,
+                        "monthly": 99
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/cards/{cardId}": {
+        "put": {
+          "summary": "Update a card product",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Updated card response",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "cardId": "card123",
+                    "name": "Updated Name",
+                    "description": "Updated Description"
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/login": {
+        "post": {
+          "summary": "Login as admin",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Login success with token",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "success": true,
+                    "token": "mock-token"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Invalid credentials",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "success": false,
+                    "message": "Invalid credentials"
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/admin-metric/logout": {
+        "post": {
+          "summary": "Logout admin",
+          "tags": [
+            "Admin Metrics"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Logged out success",
+              "content": {
+                "application/json": {
+                  "example": {
+                    "success": true,
+                    "message": "Logged out successfully"
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/version": {
+        "get": {
+          "summary": "Check App Version",
+          "description": "Endpoint to check if mobile app version requires update\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "currentVersion",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Current version of the mobile application",
+                "example": "1.2.3"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Version check completed successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "latestVersion": {
+                        "type": "string",
+                        "description": "Latest available version of the app",
+                        "example": "2.0.0"
+                      },
+                      "forceUpdate": {
+                        "type": "boolean",
+                        "description": "Whether user must update before continuing",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Validation failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "missingVersion": {
+                      "summary": "Missing version",
+                      "value": {
+                        "message": "Current version is missing",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Current version must be provided."
+                          }
+                        ]
+                      }
+                    },
+                    "invalidFormat": {
+                      "summary": "Invalid version format",
+                      "value": {
+                        "message": "Invalid version format",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
+                          }
+                        ]
+                      }
+                    },
+                    "futureVersion": {
+                      "summary": "Version cannot be greater than the latest version",
+                      "value": {
+                        "message": "Invalid version",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Current version cannot be greater than the latest version."
+                          }
+                        ]
+                      }
+                    },
+                    "majorVersionMismatch": {
+                      "summary": "Multiple version updates pending",
+                      "value": {
+                        "message": "Multiple version updates required",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Your app version (1.2.0) is more than one version behind the latest version."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/consent": {
+        "get": {
+          "summary": "Retrieve the User Consent details",
+          "description": "This API returns the Consent information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Consent details fetched successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Response message",
+                        "example": "Consent Fetched Successfully"
+                      },
+                      "consent": {
+                        "type": "array",
+                        "description": "List of consents",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "Unique identifier for the consent",
+                              "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "Type of consent (e.g., signup)",
+                              "example": "signup"
+                            },
+                            "accepted": {
+                              "type": "boolean",
+                              "description": "Whether the user accepted the consent",
+                              "example": false
+                            },
+                            "isMandatory": {
+                              "type": "boolean",
+                              "description": "Whether the consent is mandatory",
+                              "example": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Update the User Consent details",
+          "description": "This API Updates the Consent information of the user and returns the updated consent.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "List of consent acceptance details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the consent",
+                        "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                      },
+                      "accepted": {
+                        "type": "boolean",
+                        "description": "Whether the user accepted the consent",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Consent Fetched Succesfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Consent Updated succesfully",
+                        "example": "Consent Updated succesfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The consent details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save consent because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "consent"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Consent is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "summary": "Missing consent",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "consent",
+                            "message": "Consent id required"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "summary": "Invalid consent type",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "consentId",
+                            "message": "ConsentId should be of string type"
+                          },
+                          {
+                            "field": "accepted",
+                            "message": "accepted should be of boolean type"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/consent/status": {
+        "get": {
+          "summary": "Retrieve the User Consent Status",
+          "description": "This API returns the Consent Status information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Consent Status Fetched Succesfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Consent fetched succesfully",
+                        "example": "Consent Status fetched succesfully"
+                      },
+                      "consentStatus": {
+                        "type": "boolean",
+                        "description": "The consent status",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/signup-email": {
+        "post": {
+          "summary": "Register a new user",
+          "description": "This API is used to register a new user in the system. Upon successful registration:\n- The request requires the **x-app-code** header for authentication and the Partner Code to associate the customer to a particular partner.\n- An email containing a verification link is sent to the provided email address.\n- The user must click the verification link to confirm their email address.\n- Until the email is verified, the account will remain inactive.\n- To verify the email, the user needs to call the **Verify Email API** with the verification token sent in the email.\n\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's email address",
+                      "example": "user@example.com"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The user's first name",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The user's last name",
+                      "example": "Doe"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User registered successfully, email verification link sent",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "User registered successfully. Please verify your email."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error",
+                        "example": "A descriptive error message"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Optional detailed error information (only for server errors)",
+                        "example": "Detailed error information"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "MissingFields": {
+                      "summary": "Required fields are missing",
+                      "value": {
+                        "message": "One or more required fields are missing",
+                        "error": "Missing Fields"
+                      }
+                    },
+                    "EmailAlreadyExists": {
+                      "summary": "Email already registered",
+                      "value": {
+                        "message": "Email is already registered",
+                        "error": "Email Already Exists"
+                      }
+                    },
+                    "InvalidEmail": {
+                      "summary": "Email is invalid",
+                      "value": {
+                        "message": "Email is invalid",
+                        "error": "Invalid Email"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/verify-email": {
+        "put": {
+          "summary": "Verify user email address",
+          "description": "This API is used to verify the email address of a user after they click the verification link in their email. \nThe user must provide the verification token received in their email.\n\nUpon successful verification:\n- The user's email is marked as verified in the system.\n- The account will be activated.\n- A **temporary token** will be generated and returned.\n- This temporary token is required to create the user’s password in the next step.\n       \nIf the token is invalid or expired:\n- The user will receive an error response indicating the failure.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "token",
+              "in": "query",
+              "description": "The verification token sent via email",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Email verified successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message indicating the email has been verified.",
+                        "example": "Email verified successfully. Please create your password."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid token",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Error message if the token is invalid or expired",
+                        "example": "Invalid or expired token"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information",
+                        "example": "Verification failed"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "MissingToken": {
+                      "summary": "Verification token missing",
+                      "value": {
+                        "message": "Verification token is required",
+                        "error": "Missing Token"
+                      }
+                    },
+                    "InvalidToken": {
+                      "summary": "Invalid token",
+                      "value": {
+                        "message": "No email accociated with this token",
+                        "error": "Invalid token"
+                      }
+                    },
+                    "AlreadyVerified": {
+                      "summary": "Already Verified",
+                      "value": {
+                        "message": "Email is already verified",
+                        "error": "Already Verified"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signin-email": {
+        "post": {
+          "summary": "Sign in using email and password",
+          "description": "This API allows users to sign in using their email and password after verifying their email and creating a password.  \n- On successful authentication, the API provides an **accessToken** and a **refreshToken** for subsequent requests.  \n- If the system has 2FA enabled for the user, the API will provide a temporary token (**token2fa**) instead of the usual tokens.  \n- The user must then complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's email address",
+                      "example": "user@example.com"
+                    },
+                    "password": {
+                      "type": "string",
+                      "description": "The user's password",
+                      "example": "password123"
+                    }
+                  },
+                  "required": [
+                    "email",
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Sign-in successful",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      },
+                      "token2fa": {
+                        "type": "string",
+                        "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                        "example": "U2FsdGVkX1...",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "examples": {
+                    "No2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                      }
+                    },
+                    "With2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Invalid credentials"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Authentication failed"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Invalid credentials",
+                    "error": "Authentication failed"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signin-social": {
+        "post": {
+          "summary": "Sign in using Google account",
+          "description": "This API allows users to sign in using their Google account.  \n- The user needs to authenticate via Google and provide the **accessToken** returned by Google.  \n- The API will validate the **accessToken** with Google and authenticate the user.  \n- If the system has 2FA enabled for the user, the API will provide a **token2fa** instead of the usual **accessToken** and **refreshToken**.  \n- The user must complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "description": "The social provider used for signing in (e.g., google, facebook)",
+                      "example": "google"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "The OAuth token from the social provider",
+                      "example": "eyJhbGciOiJIUzI1..."
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      },
+                      "token2fa": {
+                        "type": "string",
+                        "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                        "example": "U2FsdGVkX1...",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "examples": {
+                    "No2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                      }
+                    },
+                    "With2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Invalid social token"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Authentication failed"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Invalid credentials",
+                    "error": "Authentication failed"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signout": {
+        "post": {
+          "summary": "Sign out of the system",
+          "description": "This API allows the user to sign out by invalidating the current `accessToken` and `refreshToken`.  \n- The user will be logged out, and the tokens will no longer be valid.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully signed out",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully signed out"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while signing out"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Token expired or not authorized.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "You are not authorized to access this resource. Please log in again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Forbidden"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/refresh-token": {
+        "put": {
+          "summary": "Refresh user authentication token",
+          "description": "This API allows the user to obtain a new access token and refresh token.\n- The user must provide a valid refresh token to get a new access token.\n- This process ensures that the user's session can continue without needing to sign in again.\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "The refresh token provided during sign-in *",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    }
+                  },
+                  "required": [
+                    "refreshToken"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully refreshed the token",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "accessToken": {
+                        "type": "string",
+                        "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "(Optional) A new refresh token, if a new one is issued",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Token expired or not authorized.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "You are not authorized to access this resource. Please log in again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Forbidden"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/verify-login-2fa": {
+        "post": {
+          "summary": "Verify login with 2FA (token and OTP)",
+          "description": "This API verifies the 2FA during the login process.\n- After successfully logging in with email/password or social sign-in, if 2FA is enabled, the user must provide the 2FA token.\n- The user needs to provide the OTP (One-Time Password) from their authenticator app to complete the login process.\n- The 2FA token is verified and if successful, the user is granted access and provided with JWT tokens (accessToken, refreshToken).\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token2fa": {
+                      "type": "string",
+                      "description": "Encrypted token containing the user data for 2FA.\nThis is used to validate the 2FA during login.\n",
+                      "example": "U2FsdGVkX1..."
+                    },
+                    "otp": {
+                      "type": "string",
+                      "description": "The one-time password (OTP) generated by the authenticator app (e.g., Google Authenticator).\nThis is required to complete the 2FA verification process.\n",
+                      "example": "123456"
+                    }
+                  },
+                  "required": [
+                    "token2fa",
+                    "otp"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "JWT access token that the user can use for subsequent requests.",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "JWT refresh token used to get a new access token after expiration.",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Invalid token or OTP",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid 2FA token or OTP."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/send-otp-mobile": {
+        "post": {
+          "summary": "Send OTP for Mobile Signup",
+          "description": "This API initiates the OTP sending process for mobile number signup.\n- Sends an OTP to the specified mobile number via SMS.\n- Requires the mobile country code and mobile number.\n- Generates a temporary token for OTP verification in verify otp mobile endpoint.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mobileCountryCode": {
+                      "type": "string",
+                      "description": "The Mobile Country Code",
+                      "example": "91"
+                    },
+                    "mobile": {
+                      "type": "string",
+                      "example": "9999999999"
+                    },
+                    "captchaRequest": {
+                      "type": "object",
+                      "properties": {
+                        "captcha_id": {
+                          "type": "string",
+                          "example": "c0e8f516d............"
+                        },
+                        "lot_number": {
+                          "type": "string",
+                          "example": "6ab.........................."
+                        },
+                        "pass_token": {
+                          "type": "string",
+                          "example": "3f38860968423............................."
+                        },
+                        "gen_time": {
+                          "type": "string",
+                          "example": "1747994419"
+                        },
+                        "captcha_output": {
+                          "type": "string",
+                          "example": "oJBgOJQXRSOQmiSwTwyXzW93xJfDocY9c_K....................."
+                        }
+                      },
+                      "required": [
+                        "captcha_id",
+                        "lot_number",
+                        "pass_token",
+                        "gen_time",
+                        "captcha_output"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "mobileCountryCode",
+                    "mobile",
+                    "captchaRequest"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "OTP sent successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "OTP sent successfully"
+                      },
+                      "requestToken": {
+                        "type": "string",
+                        "description": "Request Token for OTP verification",
+                        "example": "a1b2c3d4e5f6g7h8"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid mobile number or country code"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidMobile": {
+                      "summary": "Mobile number validation failure",
+                      "value": {
+                        "message": "Unable to send OTP due to validation failures",
+                        "errors": [
+                          {
+                            "field": "mobile",
+                            "message": "Invalid Mobile Number"
+                          },
+                          {
+                            "field": "mobileCountryCode",
+                            "message": "Invalid Mobile Country Code"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": " Otp limit exhausted"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "otpLimitExhausted": {
+                      "summary": "Otp limit exhausted",
+                      "value": {
+                        "message": "You have reached the maximum OTP request limit. Please try after 2 minutes."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/verify-otp-mobile": {
+        "post": {
+          "summary": "Verify mobile OTP",
+          "description": "This API verifies the OTP sent to a mobile number during the signup process.\n- Requires both the OTP received on mobile and the temporary token from the send-otp api\n- Returns temp token upon successful verification\n- The temp token can be used to retrieve mobile number details during signup\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "otp": {
+                      "type": "string",
+                      "description": "The otp sent to device",
+                      "example": "1234"
+                    },
+                    "requestToken": {
+                      "type": "string",
+                      "description": "Request Token for OTP verification received from send-otp-mobile endpoint",
+                      "example": "cder678uhgvcderijhnbgtu"
+                    }
+                  },
+                  "required": [
+                    "otp",
+                    "requestToken"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "OTP verification successful",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "OTP verified successfully"
+                      },
+                      "verifiedToken": {
+                        "type": "string",
+                        "description": "Verified token for signup-mobile",
+                        "example": "a1b2c3d4e5f6g7h8"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid or expired token",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "success": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Authentication failed",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "success": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Partner code or app code is invalid"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signup-mobile": {
+        "post": {
+          "summary": "SignUp Mobile",
+          "description": "This API helps users to sign up through their mobile.\n- The request requires the **x-app-code** header for authentication and the Partner Code to associate the customer to a particular partner. The payload includes the mobile number.\n- The mobile number must include the country code.\n- Token after verifing that otp.\n- `deviceDetail` is used to capture device-specific information for additional verification and push notification services.\n- Upon successful execution, the API returns an **authToken** that can be used to authenticate the user.\n- The **authToken** is permanent and needs to be stored securely for future authentication.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "x-app-version",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application version of this user.",
+                "example": "1.0.0"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "verifiedToken": {
+                      "type": "string",
+                      "description": "Verified token received from verify-otp-mobile endpoint.",
+                      "example": "1qsde345tfdxcvbhjuytrewsdvbnhj"
+                    },
+                    "referrerCode": {
+                      "type": "string",
+                      "description": "Referrer Code.",
+                      "example": "ABCD1234"
+                    },
+                    "mobileCountryCode": {
+                      "type": "string",
+                      "description": "Mobile Country Code",
+                      "example": "91"
+                    },
+                    "mobile": {
+                      "type": "string",
+                      "description": "Mobile number of user",
+                      "example": "9999999999"
+                    },
+                    "email": {
+                      "type": "string",
+                      "description": "Email of user",
+                      "example": "jhon@description.com"
+                    },
+                    "deviceDetail": {
+                      "type": "object",
+                      "properties": {
+                        "imei": {
+                          "type": "string",
+                          "description": "The IMEI number of the device.",
+                          "example": "863768093627018/85"
+                        },
+                        "model": {
+                          "type": "string",
+                          "description": "The model of the device.",
+                          "example": "6T"
+                        },
+                        "brand": {
+                          "type": "string",
+                          "description": "The brand of the device.",
+                          "example": "Realme"
+                        },
+                        "sysName": {
+                          "type": "string",
+                          "description": "The operating system of the device.",
+                          "example": "android"
+                        },
+                        "sysVersion": {
+                          "type": "string",
+                          "description": "The operating system version.",
+                          "example": "14"
+                        },
+                        "oneSignalId": {
+                          "type": "string",
+                          "description": "The OneSignal ID for push notifications.",
+                          "example": "b1b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b"
+                        }
+                      },
+                      "required": [
+                        "imei",
+                        "model",
+                        "brand",
+                        "sysName",
+                        "sysVersion",
+                        "oneSignalUserId",
+                        "token"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Authentication successful",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Authentication successful"
+                      },
+                      "authToken": {
+                        "type": "string",
+                        "example": "57f5671bcc06ser8b6a754c3138cf3854feeff8212535296516e35d56c3da75f:69670cd5b841b1d376e8a845d1475a77"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid APP code"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidAppcode": {
+                      "summary": "Invalid App code",
+                      "value": {
+                        "message": "Invalid APP code"
+                      }
+                    },
+                    "invalidPartnerCode": {
+                      "summary": "Invalid Partner Code",
+                      "value": {
+                        "message": "Invalid Partner Code"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signin-mobile": {
+        "post": {
+          "summary": "Sign in using mobile permanent verification code",
+          "description": "This API allows users to sign in using a permanent mobile verification code.   \n- The permanent verification code is issued to the user via the **verify-otp** API after successfully verifying their mobile number.  \n- The user must provide this verification code to authenticate.  \n- If the code is valid, the API will issue an **accessToken** and **refreshToken**.  \n- If the system has 2FA enabled for the user, the API will return a **token2fa** instead of the usual **accessToken** and **refreshToken**.  \n- The user must complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "authToken": {
+                      "type": "string",
+                      "description": "The permanent mobile verification code issued after successful mobile verification via the **verify-otp** API.",
+                      "example": "eyJhbGciOiJIUzI1..."
+                    }
+                  },
+                  "required": [
+                    "authToken"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      },
+                      "token2fa": {
+                        "type": "string",
+                        "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                        "example": "U2FsdGVkX1...",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "examples": {
+                    "No2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                      }
+                    },
+                    "With2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Invalid social token"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Authentication failed"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidAppcode": {
+                      "summary": "Invalid App code",
+                      "value": {
+                        "message": "Invalid APP code"
+                      }
+                    },
+                    "invalidPartnerCode": {
+                      "summary": "Invalid Partner Code",
+                      "value": {
+                        "message": "Invalid Partner Code"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/send-otp-email": {
+        "post": {
+          "summary": "Send OTP to EMail",
+          "description": "This API generates and sends a One-Time Password (OTP) via mail to the specified email. \n- The request requires the **authentication-token** header for authentication and includes the email in the payload. \n- Upon successful execution, the API sends an email containing an OTP, which must be provided at the **verify-otp-email** endpoint to successfully verify the email address..\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "description": "The email of the user.",
+                      "example": "user@example.com"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "An OTP has been sent to your email address for verification.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "An OTP has been sent to your email address for verification."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Email is required"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "emailRequired": {
+                      "summary": "Email is required",
+                      "value": {
+                        "message": "Email is required"
+                      }
+                    },
+                    "invalidEmail": {
+                      "summary": "Invalid Email",
+                      "value": {
+                        "message": "Invalid email address."
+                      }
+                    },
+                    "emailVerified": {
+                      "summary": "Email verified",
+                      "value": {
+                        "message": "Email is already verified"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid Bearer code"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/verify-otp-email": {
+        "post": {
+          "summary": "Verify OTP",
+          "description": "This API verifies the One-Time Password (OTP) sent to the specified Email.\n- The request body must include the OTP received from the **verification email** sent via **send-otp-email** endpoint.\n- This API validates the OTP and if successful, email gets verified. \n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "otp": {
+                      "type": "string",
+                      "description": "The OTP to verify.",
+                      "example": "123456"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "OTP verified successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Your email address has been successfully verified."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid or expired OTP"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid authtoken"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/captcha-challenge": {
+        "get": {
+          "summary": "Get CAPTCHA configuration",
+          "description": "Initializes Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+          "tags": [
+            "Captcha"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "CAPTCHA initialized successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha challenge initialized successfully."
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "data": {
+                        "type": "object",
+                        "properties": {
+                          "lot_number": {
+                            "type": "string",
+                            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                          },
+                          "captcha_type": {
+                            "type": "string",
+                            "example": "slide"
+                          },
+                          "captcha_output": {
+                            "type": "string",
+                            "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+                          },
+                          "pass_token": {
+                            "type": "string",
+                            "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+                          },
+                          "captcha_id": {
+                            "type": "string",
+                            "example": "fb362ff464a632747b0dd0ea90bab013"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        },
+        "post": {
+          "summary": "Validate CAPTCHA configuration",
+          "description": "Validate Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+          "tags": [
+            "Captcha"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mobile": {
+                      "type": "string",
+                      "example": "9456262167"
+                    },
+                    "captcha_id": {
+                      "type": "string",
+                      "example": "d81db9ghjk82bc8abb8b93a6b24b"
+                    },
+                    "lot_number": {
+                      "type": "string",
+                      "example": "362ff4642747b0dd0ea90bab013ss"
+                    },
+                    "captcha_output": {
+                      "type": "string",
+                      "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+                    },
+                    "pass_token": {
+                      "type": "string",
+                      "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+                    },
+                    "gen_time": {
+                      "type": "string",
+                      "example": "1747751473"
+                    }
+                  },
+                  "required": [
+                    "mobile",
+                    "captcha_id",
+                    "lot_number",
+                    "captcha_output",
+                    "pass_token",
+                    "gen_time"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "CAPTCHA validated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha validated successfully."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha validation failed."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "pass_token expire"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/card": {
+        "get": {
+          "summary": "Fetch user cards",
+          "description": "Retrieve a list of all cards associated with the authenticated user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "The type of card to be fetched.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "physical"
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "description": "The status of card.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "active"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved the list of cards.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "List of cards retrieved successfully"
+                      },
+                      "cards": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "virtual"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Current status of the card",
+                              "example": "active",
+                              "enum": [
+                                "notActivated",
+                                "active",
+                                "locked",
+                                "canceled"
+                              ]
+                            },
+                            "last4Digits": {
+                              "type": "string",
+                              "example": "8377"
+                            },
+                            "expirationMonth": {
+                              "type": "string",
+                              "example": "4"
+                            },
+                            "expirationYear": {
+                              "type": "string",
+                              "example": "2030"
+                            },
+                            "productType": {
+                              "type": "string",
+                              "example": "PLATINUM",
+                              "enum": [
+                                "PLATINUM"
+                              ]
+                            },
+                            "productScheme": {
+                              "type": "string",
+                              "example": "VISA",
+                              "enum": [
+                                "VISA"
+                              ]
+                            },
+                            "productCode": {
+                              "type": "string",
+                              "example": "ABCD1234"
+                            },
+                            "cardName": {
+                              "type": "string",
+                              "example": "Regular"
+                            },
+                            "cardMaterial": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "cardMaterialName": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "isPinActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "isActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "example": "4561228"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "example": "Offer card"
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "example": "card",
+                                    "enum": [
+                                      "card"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "number",
+                                    "example": 0
+                                  },
+                                  "valueType": {
+                                    "type": "string",
+                                    "example": "amount",
+                                    "enum": [
+                                      "amount",
+                                      "percentage"
+                                    ]
+                                  },
+                                  "hasClaimed": {
+                                    "type": "boolean",
+                                    "example": false
+                                  },
+                                  "fees": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "example": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223"
+                                        },
+                                        "type": {
+                                          "type": "string",
+                                          "example": "activation",
+                                          "enum": [
+                                            "activation",
+                                            "rental"
+                                          ]
+                                        },
+                                        "label": {
+                                          "type": "string",
+                                          "example": "Card Fee"
+                                        },
+                                        "amount": {
+                                          "type": "number",
+                                          "example": 100
+                                        },
+                                        "interval": {
+                                          "type": "string",
+                                          "example": "lifetime"
+                                        },
+                                        "frequency": {
+                                          "type": "string",
+                                          "example": "one-time"
+                                        },
+                                        "coolOffPeriod": {
+                                          "type": "integer",
+                                          "example": 0
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "orderNumber": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "orderDate": {
+                              "type": "Date",
+                              "example": "2025-04-23T17:53:52.000Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "physicalCard": {
+                      "summary": "Physical card details",
+                      "value": {
+                        "message": "Successfully retrieved user cards.",
+                        "cards": [
+                          {
+                            "id": "344fb823-9949-4401-829a-6e2c87825b10",
+                            "type": "physical",
+                            "status": "notActivated",
+                            "last4Digits": "9678",
+                            "expirationMonth": "01",
+                            "expirationYear": "2029",
+                            "productType": "SIGNATURE",
+                            "productScheme": "VISA",
+                            "productCode": "4578589k",
+                            "cardName": "Regular",
+                            "cardMaterial": "metal",
+                            "cardMaterialName": "Metal",
+                            "isPinActivated": false,
+                            "isActivated": false,
+                            "offers": [
+                              {
+                                "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                                "code": "4561228",
+                                "name": "Offer card",
+                                "type": "card",
+                                "value": 0,
+                                "valueType": "amount",
+                                "hasClaimed": false,
+                                "fees": [
+                                  {
+                                    "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 100,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  },
+                                  {
+                                    "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 500,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  }
+                                ]
+                              }
+                            ],
+                            "displayName": "asdasd",
+                            "orderNumber": "263729",
+                            "orderDate": "2025-04-30T13:05:00.000Z"
+                          }
+                        ]
+                      }
+                    },
+                    "virtualCard": {
+                      "summary": "Virtual card details",
+                      "value": {
+                        "message": "Successfully retrieved user cards.",
+                        "cards": [
+                          {
+                            "id": "45e88904-74b9-43b7-9e9b-ff16127078e1",
+                            "type": "virtual",
+                            "status": "active",
+                            "last4Digits": "2839",
+                            "expirationMonth": "03",
+                            "expirationYear": "2029",
+                            "productType": "PLATINUM",
+                            "productScheme": "VISA",
+                            "productCode": "82a7df4f",
+                            "cardName": "Neo Card",
+                            "isPinActivated": false,
+                            "isActivated": false,
+                            "offers": [
+                              {
+                                "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                                "code": "4561228",
+                                "name": "Offer card",
+                                "type": "card",
+                                "value": 0,
+                                "valueType": "amount",
+                                "hasClaimed": false,
+                                "fees": [
+                                  {
+                                    "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 100,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  },
+                                  {
+                                    "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 500,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The request is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid request payload."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No cards found or user not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {}
+                  },
+                  "examples": {
+                    "noCards": {
+                      "summary": "No cards found",
+                      "value": {
+                        "message": "No cards found for the user"
+                      }
+                    },
+                    "userNotFound": {
+                      "summary": "User not found",
+                      "value": {
+                        "message": "User not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Add new card",
+          "description": "Add new card for the authenticated user with the provided details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to add a card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "coupon": {
+                      "type": "string",
+                      "example": "XYZ1234"
+                    },
+                    "fees": {
+                      "type": "array",
+                      "example": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "dispalyName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "cardMaterialCode": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "shipTo": {
+                      "type": "object",
+                      "properties": {
+                        "firstName": {
+                          "type": "string",
+                          "example": "John"
+                        },
+                        "lastName": {
+                          "type": "string",
+                          "example": "Doe"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "line2": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "city": {
+                          "type": "string",
+                          "example": "Mumbai"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "Maharashtra"
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "example": "400001"
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "example": "IN"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "India"
+                        },
+                        "phoneNumber": {
+                          "type": "string",
+                          "example": "9987454512"
+                        }
+                      }
+                    },
+                    "billTo": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string",
+                          "example": "456 Avenue Road"
+                        },
+                        "line2": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "city": {
+                          "type": "string",
+                          "example": "Delhi"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "Delhi"
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "example": "110001"
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "example": "IN"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "India"
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCard": {
+                    "summary": "Example request for virtual card",
+                    "value": {
+                      "code": "ABCD1234",
+                      "coupon": "XYZ1234",
+                      "fees": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                      ]
+                    }
+                  },
+                  "physicalCard": {
+                    "summary": "Example request for physical card",
+                    "value": {
+                      "code": "ABCD1234",
+                      "coupon": "XYZ1234",
+                      "fees": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3"
+                      ],
+                      "dispalyName": "Jane Doe",
+                      "cardMaterialCode": "MAT-PHY-01",
+                      "shipTo": {
+                        "firstname": "John",
+                        "lastName": "Doe",
+                        "line1": "789 Main Road",
+                        "line2": "Near Metro Station",
+                        "city": "Pune",
+                        "region": "Maharashtra",
+                        "postalCode": "411001",
+                        "countryCode": "IN",
+                        "country": "India",
+                        "phoneNumber": "9874561238"
+                      },
+                      "billTo": {
+                        "line1": "123 Office Lane",
+                        "line2": "Suite 21B",
+                        "city": "Bangalore",
+                        "region": "Karnataka",
+                        "postalCode": "560001",
+                        "countryCode": "IN",
+                        "country": "India"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully added a new card.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully added a new card."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "virtualCard": {
+                      "summary": "Virtual card created successfully",
+                      "value": {
+                        "message": "Successfully added a new card.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "active",
+                          "amount": 1000,
+                          "frequency": "per24HourPeriod",
+                          "last4Digits": "8377",
+                          "expirationMonth": "04",
+                          "expirationYear": "2030",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "ABCD1234",
+                          "isPinActivated": false,
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    },
+                    "physicalCard": {
+                      "summary": "Physical card created successfully",
+                      "value": {
+                        "message": "Successfully added a new card.",
+                        "card": {
+                          "id": "b345a1ac-a403-4c3f-b334-5b3f676e3822",
+                          "type": "physical",
+                          "status": "notActivated",
+                          "amount": 0,
+                          "frequency": "per24HourPeriod",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "PHYS5678",
+                          "cardMaterial": "plastic",
+                          "isPinActivated": false,
+                          "orderNumber": 1,
+                          "cardHolder": {
+                            "id": "b9123fa1-59e3-4e21-bd6a-9cf10dc12f44",
+                            "firstName": "Jane",
+                            "lastName": "Doe"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to add card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "code",
+                            "message": "Invalid Card Product Code"
+                          },
+                          {
+                            "field": "coupon",
+                            "message": "Invalid Coupon Code"
+                          }
+                        ]
+                      }
+                    },
+                    "FeeDetailValidationFailure": {
+                      "summary": "Fee detail validation failure",
+                      "value": {
+                        "message": "Unable to add card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "fees",
+                            "message": "Fee details are required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee ID(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3, 114fe929-76e6-4fab-9de3-9a7d6ee9d3d5) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided for the card product."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "activation type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Exactly one activation type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "rental type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Exactly one rental type fee is required."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}": {
+        "get": {
+          "summary": "Retrieve card details",
+          "description": "Fetch detailed information about a specific card using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The unique identifier of the card.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Card details retrieved successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details retrieved successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "example": "68c44898-a805-4d44-8c6d-3e9367343e96"
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "example": "Vest"
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "example": "QA"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Modify card details",
+          "description": "Update specific details of a card, such as status or usage restrictions.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to update for the card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "Usage frequency restrictions on the card.",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Maximum allowable limit for card transactions.",
+                      "example": 1000
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Updated status of the card.",
+                      "example": "active",
+                      "enum": [
+                        "notActivated",
+                        "active",
+                        "locked",
+                        "canceled"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully updated card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "status is required"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "amount is required"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "Invalid card frequency"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "amount",
+                            "message": "Invalid card amount"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample3": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          },
+                          {
+                            "field": "status",
+                            "message": "Invalid card status"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/activate": {
+        "put": {
+          "summary": "Activate a card",
+          "description": "Mark a card as active using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Required only for **physical cards** to verify last 4 digits and expiration details.\n\nFor **virtual cards**, the body should be omitted.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "last4Digits": {
+                      "type": "string",
+                      "description": "Last 4 digits of the physical card.",
+                      "example": "4710"
+                    },
+                    "expirationMonth": {
+                      "type": "string",
+                      "description": "Expiration month of the physical card.",
+                      "example": "10"
+                    },
+                    "expirationYear": {
+                      "type": "string",
+                      "description": "Expiration year of the physical card.",
+                      "example": "2029"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Amount ( in cents).",
+                      "example": 5000
+                    },
+                    "frequency": {
+                      "type": "string",
+                      "description": "frequency.",
+                      "example": "allTime"
+                    }
+                  }
+                }
+              }
+            },
+            "required": false
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully activated the card.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card activation successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "e65a8911-9feb-44f7-86f8-64cc116d9e9b"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "physical"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "The updated status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "6922"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "11"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2029"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "4578589k"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/secure": {
+        "get": {
+          "summary": "Retrieve secure card details",
+          "description": "Fetch encrypted card information using the card ID and session ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique identifier of the card",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "sessionid",
+              "in": "header",
+              "description": "Base64-encoded session ID of the user requesting the encrypted data",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Secure card details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid card ID",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/cards": {
+        "get": {
+          "summary": "Get all cards for all users",
+          "description": "Retrieve a list of all cards associated with users, with optional filters for pagination.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "The page number for pagination (default is 1).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "1"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "The number of items per page for pagination (default is 10).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "4"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "Search users by first name, last name, or email.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "John"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of cards retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully retrieved all cards."
+                      },
+                      "cards": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "f77d55d1-1f83-41a4-817f-a205974fb0ff"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "virtual"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Current status of the card.",
+                              "example": "notActivated",
+                              "enum": [
+                                "notActivated",
+                                "active",
+                                "locked",
+                                "canceled"
+                              ]
+                            },
+                            "last4Digits": {
+                              "type": "string",
+                              "example": "0000"
+                            },
+                            "expirationMonth": {
+                              "type": "string",
+                              "example": "00"
+                            },
+                            "expirationYear": {
+                              "type": "string",
+                              "example": "0000"
+                            },
+                            "productType": {
+                              "type": "string",
+                              "example": "PLATINUM",
+                              "enum": [
+                                "PLATINUM"
+                              ]
+                            },
+                            "productScheme": {
+                              "type": "string",
+                              "example": "VISA",
+                              "enum": [
+                                "VISA"
+                              ]
+                            },
+                            "productCode": {
+                              "type": "string",
+                              "example": "ABCD1234"
+                            },
+                            "cardName": {
+                              "type": "string",
+                              "example": "Regular"
+                            },
+                            "cardMaterial": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "cardMaterialName": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "isPinActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "orderNumber": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "orderDate": {
+                              "type": "Date",
+                              "example": "2025-04-23T17:53:52.000Z"
+                            },
+                            "cardHolder": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "example": "68c44898-a805-4d44-8c6d-3e9367343e96"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "example": "Vest"
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "example": "QA"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total": {
+                        "type": "integer",
+                        "example": 11
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 3
+                      },
+                      "limit": {
+                        "type": "string",
+                        "example": "4"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "success": {
+                      "summary": "Successfully retrieved all cards",
+                      "value": {
+                        "message": "Successfully retrieved all cards.",
+                        "cards": [
+                          {
+                            "id": "f77d55d1-1f83-41a4-817f-a205974fb0ff",
+                            "type": "virtual",
+                            "status": "notActivated",
+                            "last4Digits": "0000",
+                            "expirationMonth": "00",
+                            "expirationYear": "0000",
+                            "productType": "PLATINUM",
+                            "productScheme": "VISA",
+                            "productCode": "ABCD1234",
+                            "cardName": "Regular",
+                            "cardMaterial": "plastic",
+                            "cardMaterialName": "plastic",
+                            "isPinActivated": true,
+                            "orderNumber": 542596,
+                            "orderDate": "2025-04-23T17:53:52.000Z",
+                            "cardHolder": {
+                              "id": "68c44898-a805-4d44-8c6d-3e9367343e96",
+                              "firstName": "Vest",
+                              "lastName": "QA"
+                            }
+                          }
+                        ],
+                        "total": 11,
+                        "totalPages": 3,
+                        "limit": "4"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Customer not found or no cards found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "summary": "Customer not found",
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "noCardsFound": {
+                      "summary": "No cards found",
+                      "value": {
+                        "message": "No cards found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card": {
+        "post": {
+          "summary": "Create a card for a user",
+          "description": "Allows a Superadmin to create a card for a specific user.\nThe card details, such as usage frequency, amount limit can be specified in the request body.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user for whom the card is being created.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Card creation details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "The frequency of card usage",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "The amount limit for the card",
+                      "example": 1000
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Card created successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card created successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "cardActivated": {
+                      "summary": "Card created and activated",
+                      "value": {
+                        "message": "Card created successfully.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "active",
+                          "amount": 1000,
+                          "frequency": "per24HourPeriod",
+                          "last4Digits": "8377",
+                          "expirationMonth": "04",
+                          "expirationYear": "2030",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "ABCD1234",
+                          "isPinActivated": true,
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    },
+                    "cardNotActivated": {
+                      "summary": "Card created but not activated",
+                      "value": {
+                        "message": "Card created successfully but unable to activate.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "not_activated",
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Invalid fields in the request",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "status is required"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "amount is required"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          }
+                        ]
+                      }
+                    },
+                    "userAlreadyHasCard": {
+                      "summary": "User already has a card",
+                      "value": {
+                        "message": "Unable to save card because the user already has a card",
+                        "errors": [
+                          {
+                            "field": "userId",
+                            "message": "User already has a card"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User not found or not allowed to add cards",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User not found or not allowed to add cards"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card/{cardId}": {
+        "get": {
+          "summary": "Get card details for a user",
+          "description": "Retrieves the details of a specific card for a user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The ID of the card.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Card details retrieved successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details retrieved successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidCardId": {
+                      "summary": "Invalid card ID",
+                      "value": {
+                        "message": "Invalid card ID"
+                      }
+                    },
+                    "invalidUser": {
+                      "summary": "Invalid user",
+                      "value": {
+                        "message": "Invalid user"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update card details for a user",
+          "description": "Updates the details of a specific card for a user. The card details, such as usage frequency, amount limit, and status, can be specified in the request body.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to update for the card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "Usage frequency restrictions on the card.",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Maximum allowable limit for card transactions.",
+                      "example": 1000
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Updated status of the card.",
+                      "example": "active",
+                      "enum": [
+                        "notActivated",
+                        "active",
+                        "locked",
+                        "canceled"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully updated card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is invalid"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "summary": "Invalid frequency",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "frequency",
+                            "message": "Invalid card frequency"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "summary": "Invalid amount",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "amount",
+                            "message": "Invalid card amount"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample3": {
+                      "summary": "Invalid status",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "Invalid card status"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card/{cardId}/secure": {
+        "get": {
+          "summary": "Get secure card details for a user",
+          "description": "Retrieves the secure details of a specific card for a user. This includes sensitive information that requires additional authorization.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "sessionid",
+              "in": "header",
+              "description": "Base64-encoded session ID of the user requesting the encrypted data",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Secure card details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "400": {
+              "description": "Unable to retrieve secure card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidCardId": {
+                      "summary": "Invalid card ID",
+                      "value": {
+                        "message": "Invalid card ID"
+                      }
+                    },
+                    "sessionExpired": {
+                      "summary": "Unable to retrieve secure card details",
+                      "value": {
+                        "message": "Session expired"
+                      }
+                    },
+                    "invalidUser": {
+                      "summary": "Invalid user",
+                      "value": {
+                        "message": "Invalid user"
+                      }
+                    },
+                    "invalidSession": {
+                      "summary": "Invalid session",
+                      "value": {
+                        "message": "Invalid session"
+                      }
+                    },
+                    "sessionIdNotFound": {
+                      "summary": "Session ID not found",
+                      "value": {
+                        "message": "Session ID not found in headers"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/coupon": {
+        "get": {
+          "summary": "Validate coupon code",
+          "description": "Validate a coupon code to check if it is valid and can be applied to a card.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "description": "Partner code of this user.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "description": "Application code used for validating mobile-based requests.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "couponCode",
+              "in": "query",
+              "description": "The coupon code to be validated.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "ABCD1234"
+            },
+            {
+              "name": "productCode",
+              "in": "query",
+              "description": "The product code to be validated.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "PROD1234"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Coupon code is valid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Coupon code is valid"
+                      },
+                      "coupon": {
+                        "type": "object",
+                        "properties": {
+                          "discount": {
+                            "type": "number",
+                            "description": "Discount value to be applied to the card",
+                            "example": 100
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "Type of discount applied",
+                            "example": "flat",
+                            "enum": [
+                              "percentage",
+                              "flat"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Validation error.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidProductCode": {
+                      "summary": "Invalid product code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "productCode",
+                            "message": "Invalid product code"
+                          }
+                        ]
+                      }
+                    },
+                    "invalidCouponCode": {
+                      "summary": "Invalid coupon code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "couponCode",
+                            "message": "Invalid coupon code."
+                          }
+                        ]
+                      }
+                    },
+                    "couponAlreadyUsed": {
+                      "summary": "Coupon code already used",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "couponCode",
+                            "message": "Coupon code already used."
+                          }
+                        ]
+                      }
+                    },
+                    "invalidUserEmail": {
+                      "summary": "Email not associated with coupon code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "userEmail",
+                            "message": "The user email does not registered."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/order/{orderNumber}": {
+        "get": {
+          "summary": "Get card order by order ID",
+          "description": "Retrieves detailed information of a card order using the provided order ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used to authenticate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "orderNumber",
+              "in": "path",
+              "description": "Unique order ID of the card",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Card fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "card fetched successfully"
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "virtual",
+                              "physical"
+                            ]
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string"
+                          },
+                          "expirationMonth": {
+                            "type": "integer"
+                          },
+                          "expirationYear": {
+                            "type": "integer"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "enum": [
+                              "VISA",
+                              "MASTERCARD"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCSG"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "fees": {
+                            "type": "object",
+                            "properties": {
+                              "fees": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "coupon": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          },
+                          "shipTo": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              },
+                              "city": {
+                                "type": "string"
+                              },
+                              "line1": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              },
+                              "postalCode": {
+                                "type": "string"
+                              },
+                              "countryCode": {
+                                "type": "string"
+                              },
+                              "phoneNumber": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "billTo": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "city": {
+                                "type": "string"
+                              },
+                              "line1": {
+                                "type": "string"
+                              },
+                              "line2": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              },
+                              "postalCode": {
+                                "type": "string"
+                              },
+                              "countryCode": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "physicalCard": {
+                      "summary": "Physical card order",
+                      "value": {
+                        "message": "card fetched successfully",
+                        "card": {
+                          "id": "36da5b3b-f836-467c-aca9-d2de48248ce5",
+                          "type": "physical",
+                          "status": "notActivated",
+                          "last4Digits": "5817",
+                          "expirationMonth": 7,
+                          "expirationYear": 2029,
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "4578589k",
+                          "cardMaterial": "metal",
+                          "isPinActivated": false,
+                          "orderNumber": "000001",
+                          "fees": {
+                            "fees": [],
+                            "coupon": null
+                          },
+                          "shipTo": {
+                            "firstName": "John",
+                            "lastName": "Doe",
+                            "city": "Mumbai",
+                            "line1": "123 Street Name",
+                            "line2": "123 Street Name",
+                            "region": "Maharashtra",
+                            "country": "India",
+                            "postalCode": "400001",
+                            "countryCode": "IN",
+                            "phoneNumber": "9987339458"
+                          },
+                          "billTo": {
+                            "city": "Delhi",
+                            "line1": "456 Avenue Road",
+                            "line2": "456 Avenue Road",
+                            "region": "Delhi",
+                            "country": "India",
+                            "postalCode": "110001",
+                            "countryCode": "IN"
+                          }
+                        }
+                      }
+                    },
+                    "virtualCard": {
+                      "summary": "Virtual card order",
+                      "value": {
+                        "message": "card fetched successfully",
+                        "card": {
+                          "id": "98ad4df2-7c69-432b-9fb7-d9dc128ac250",
+                          "type": "virtual",
+                          "status": "active",
+                          "last4Digits": "4021",
+                          "expirationMonth": 6,
+                          "expirationYear": 2030,
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "VIRT8901",
+                          "orderNumber": "000007",
+                          "isPinActivated": true,
+                          "fees": {
+                            "fees": [],
+                            "coupon": null
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No cards found or user not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {}
+                  },
+                  "examples": {
+                    "noCards": {
+                      "summary": "No cards found",
+                      "value": {
+                        "message": "card not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/address": {
+        "get": {
+          "summary": "Get user address for card operations",
+          "description": "Fetches the user's address to be used for card issuance.  \nThe address can originate from either a previously issued card or a completed KYC.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used for validating mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully fetched user address",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "address fetched successfully"
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "address": {
+                            "type": "object",
+                            "properties": {
+                              "firstName": {
+                                "type": "string",
+                                "example": "John"
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "example": "Doe"
+                              },
+                              "city": {
+                                "type": "string",
+                                "example": "Delhi"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "example": "123 Street Name"
+                              },
+                              "line2": {
+                                "type": "string",
+                                "example": "lal chowk"
+                              },
+                              "region": {
+                                "type": "string",
+                                "example": "Delhi"
+                              },
+                              "country": {
+                                "type": "string",
+                                "example": "India"
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "example": "400001"
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "example": "IN"
+                              },
+                              "phoneNumber": {
+                                "type": "string",
+                                "example": "9987339458"
+                              }
+                            }
+                          },
+                          "source": {
+                            "type": "string",
+                            "example": "card",
+                            "enum": [
+                              "card",
+                              "kyc"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "fromCard": {
+                      "summary": "Address from card source",
+                      "value": {
+                        "message": "address fetched successfully",
+                        "address": {
+                          "address": {
+                            "firstName": "John",
+                            "lastName": "Doe",
+                            "city": "Delhi",
+                            "line1": "123 Street Name",
+                            "line2": "lal chowk",
+                            "region": "Delhi",
+                            "country": "India",
+                            "postalCode": "400001",
+                            "countryCode": "IN",
+                            "phoneNumber": "9987339458"
+                          },
+                          "source": "card"
+                        }
+                      }
+                    },
+                    "fromKyc": {
+                      "summary": "Address from KYC source",
+                      "value": {
+                        "message": "address fetched successfully",
+                        "address": {
+                          "address": {
+                            "firstName": "John",
+                            "lastName": "Doe",
+                            "city": "Delhi",
+                            "line1": "123 Street Name",
+                            "line2": "lal chowk",
+                            "region": "Delhi",
+                            "country": "India",
+                            "postalCode": "400001",
+                            "countryCode": "IN"
+                          },
+                          "source": "kyc"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No address found for this user",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "No address found for this user"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "noAddress": {
+                      "summary": "No address saved",
+                      "value": {
+                        "message": "No address found for this user"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/pin": {
+        "put": {
+          "summary": "Update Card PIN",
+          "description": "Update the encrypted PIN of a card using its unique identifier.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "sessionid",
+              "in": "header",
+              "description": "Base64-encoded session ID of the user",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique ID of the card to update PIN for",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "iv": {
+                      "type": "string",
+                      "description": "Initialization vector used for PIN encryption",
+                      "example": "wsZy5F3XAxgziyAolEiqRA=="
+                    },
+                    "pin": {
+                      "type": "string",
+                      "description": "Encrypted PIN value",
+                      "example": "cvbABC618qTW+vDSBH6c1ApKy6xDO2hQ5MQt9dYCDhc="
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Card PIN updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card PIN updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid card ID or request body",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID or PIN format"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Card not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{offerId}/claim": {
+        "get": {
+          "summary": "Get claimable cards for a given offer",
+          "description": "Fetches a list of claimable cards for a user based on the specified offer ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for mobile-based authentication.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "offerId",
+              "in": "path",
+              "description": "Unique identifier of the offer",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Claimable cards fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Claimable cards fetched successfully"
+                      },
+                      "cards": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "example": "virtual"
+                            },
+                            "scheme": {
+                              "type": "string",
+                              "example": "VISA"
+                            },
+                            "code": {
+                              "type": "string",
+                              "example": "05b0cb49"
+                            },
+                            "label": {
+                              "type": "string",
+                              "example": "LQUID PLATINUM"
+                            },
+                            "description": {
+                              "type": "string",
+                              "example": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%"
+                            },
+                            "fees": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "coolOffPeriod": {
+                                    "type": "number"
+                                  },
+                                  "frequency": {
+                                    "type": "string"
+                                  },
+                                  "interval": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "cardMaterial": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "fees": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "number"
+                                      },
+                                      "coolOffPeriod": {
+                                        "type": "number"
+                                      },
+                                      "frequency": {
+                                        "type": "string"
+                                      },
+                                      "interval": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "virtualCardExample": {
+                      "summary": "Virtual card with base activation fee",
+                      "value": {
+                        "message": "Claimable cards fetched successfully",
+                        "cards": [
+                          {
+                            "type": "virtual",
+                            "scheme": "VISA",
+                            "code": "05b0cb49",
+                            "label": "LQUID PLATINUM",
+                            "description": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%",
+                            "fees": [
+                              {
+                                "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                "type": "activation",
+                                "label": "Card Fee",
+                                "amount": 0,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            ],
+                            "cardMaterial": []
+                          }
+                        ]
+                      }
+                    },
+                    "physicalCardExample": {
+                      "summary": "Physical card with multiple card material fee options",
+                      "value": {
+                        "message": "Claimable cards fetched successfully",
+                        "cards": [
+                          {
+                            "type": "physical",
+                            "scheme": "VISA",
+                            "code": "73c436a7",
+                            "label": "LQUID CHOICE",
+                            "description": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%",
+                            "fees": [
+                              {
+                                "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                "type": "activation",
+                                "label": "Card Fee",
+                                "amount": 0,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            ],
+                            "cardMaterial": [
+                              {
+                                "code": "plastic",
+                                "name": "plastic",
+                                "fees": {
+                                  "id": "8af5a4c8-f02e-11ef-a4ff-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "Card Fee",
+                                  "amount": 1000,
+                                  "coolOffPeriod": 0,
+                                  "frequency": "one-time",
+                                  "interval": "lifetime"
+                                }
+                              },
+                              {
+                                "code": "metal",
+                                "name": "metal",
+                                "fees": {
+                                  "id": "45b11804-23ff-11f0-a26c-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "One-Time fee for plastic cards",
+                                  "amount": 0,
+                                  "coolOffPeriod": 0,
+                                  "frequency": "one-time",
+                                  "interval": "lifetime"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No claimable cards found for this offer",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "No claimable cards found for this offer"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/claim": {
+        "post": {
+          "summary": "Claim a Card (Virtual or Physical)",
+          "description": "Allows a user to claim a virtual or physical card using an offer. The request payload varies depending on the card type.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique identifier for the user or session claiming the card.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "offerId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "0d24f14e-2ca3-4f2e-8900-73cda36f335c"
+                    },
+                    "code": {
+                      "type": "string",
+                      "example": "82a7df4f"
+                    },
+                    "fees": {
+                      "type": "array",
+                      "example": [
+                        "dcaece42-0ba8-11f0-a26c-06d39f4fa223"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "example": "asdasd"
+                    },
+                    "cardMaterialCode": {
+                      "type": "string",
+                      "example": "metal"
+                    },
+                    "shipTo": {
+                      "type": "object",
+                      "properties": {
+                        "firstName": {
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "type": "string"
+                        },
+                        "line1": {
+                          "type": "string"
+                        },
+                        "line2": {
+                          "type": "string"
+                        },
+                        "city": {
+                          "type": "string"
+                        },
+                        "region": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "countryCode": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "type": "string"
+                        },
+                        "phoneNumber": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "billTo": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string"
+                        },
+                        "city": {
+                          "type": "string"
+                        },
+                        "region": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "countryCode": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCard": {
+                    "summary": "Virtual card claim request",
+                    "value": {
+                      "offerId": "0d24f14e-2ca3-4f2e-8900-73cda36f335c",
+                      "code": "82a7df4f",
+                      "fees": [
+                        "dcaece42-0ba8-11f0-a26c-06d39f4fa223"
+                      ]
+                    }
+                  },
+                  "physicalCard": {
+                    "summary": "Physical card claim request",
+                    "value": {
+                      "offerId": "0d24f14e-2ca3-4f2e-8900-73cda36f335c",
+                      "code": "4578589l",
+                      "fees": [
+                        "dcaece42-0ba8-11f0-a26c-06d39f4fa223",
+                        "78a54dc0-2101-11f0-99a4-0242ac11000f"
+                      ],
+                      "displayName": "asdasd",
+                      "cardMaterialCode": "metal",
+                      "shipTo": {
+                        "firstName": "John",
+                        "lastName": "Doe",
+                        "line1": "123 Street Name",
+                        "line2": "lal chowk 1",
+                        "city": "Delhi",
+                        "region": "Delhi",
+                        "postalCode": "400001",
+                        "countryCode": "IN",
+                        "country": "India",
+                        "phoneNumber": "9987339458"
+                      },
+                      "billTo": {
+                        "line1": "456 Avenue Road",
+                        "city": "mumbai",
+                        "region": "mumbai",
+                        "postalCode": "110001",
+                        "countryCode": "IN",
+                        "country": "India"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Card created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card created successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "type": "number"
+                          },
+                          "frequency": {
+                            "type": "string"
+                          },
+                          "last4Digits": {
+                            "type": "string"
+                          },
+                          "expirationMonth": {
+                            "type": "string"
+                          },
+                          "expirationYear": {
+                            "type": "string"
+                          },
+                          "cardProduct": {
+                            "type": "string"
+                          },
+                          "cardScheme": {
+                            "type": "string"
+                          },
+                          "cardCode": {
+                            "type": "string"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean"
+                          },
+                          "orderNumber": {
+                            "type": "string"
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "virtualCard": {
+                      "summary": "Successful virtual card creation",
+                      "value": {
+                        "message": "Card created successfully.",
+                        "card": {
+                          "id": "29eff3eb-97a5-48a4-945a-343aabea3869",
+                          "type": "virtual",
+                          "status": "active",
+                          "amount": 500,
+                          "frequency": "per24HourPeriod",
+                          "last4Digits": "0000",
+                          "expirationMonth": "00",
+                          "expirationYear": "0000",
+                          "cardProduct": "SIGNATURE",
+                          "cardScheme": "VISA",
+                          "cardCode": "4578589l",
+                          "isPinActivated": false,
+                          "cardHolder": {
+                            "id": "e9b63297-3d39-4e49-911c-23bdd0894030",
+                            "firstName": "VishalApproved",
+                            "lastName": "Gupta"
+                          }
+                        }
+                      }
+                    },
+                    "physicalCard": {
+                      "summary": "Successful physical card creation",
+                      "value": {
+                        "message": "Card created successfully.",
+                        "card": {
+                          "id": "bb35ca06-1f4e-451a-a2a7-4644f2b409d0",
+                          "type": "physical",
+                          "status": "notActivated",
+                          "amount": 0,
+                          "frequency": "per24HourPeriod",
+                          "cardProduct": "SIGNATURE",
+                          "cardScheme": "VISA",
+                          "cardCode": "4578589l",
+                          "isPinActivated": false,
+                          "orderNumber": "951807",
+                          "cardHolder": {
+                            "id": "e9b63297-3d39-4e49-911c-23bdd0894030",
+                            "firstName": "VishalApproved",
+                            "lastName": "Gupta"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Validation error during card claim",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to Claim card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "alreadyClaimed": {
+                      "summary": "Offer already used",
+                      "value": {
+                        "message": "Unable to Claim card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "offerId",
+                            "message": "This card has already been claimed"
+                          }
+                        ]
+                      }
+                    },
+                    "missingPhysicalFields": {
+                      "summary": "Missing fields for physical card",
+                      "value": {
+                        "message": "Unable to Create card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "shipTo",
+                            "message": "shipTo is required"
+                          },
+                          {
+                            "field": "cardMaterialCode",
+                            "message": "cardMaterialCode is required"
+                          },
+                          {
+                            "field": "displayName",
+                            "message": "displayName is required"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User or offer not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Offer or user not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/generate-2fa": {
+        "get": {
+          "summary": "Generate 2FA secret key and QR code for the user",
+          "description": "This API generates a new 2FA secret key for the user, which can be used with an authenticator app (e.g., Google Authenticator).\nIt also returns the QR code data as a Base64 string, which can be scanned by the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA secret and QR code generated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message",
+                        "example": "2FA secret generated successfully."
+                      },
+                      "qrCodeData": {
+                        "type": "string",
+                        "description": "QR code image data for scanning",
+                        "example": "data:image/png;base64,iVBORw0..."
+                      },
+                      "secret": {
+                        "type": "string",
+                        "description": "The secret, in case user wants to manually enter it",
+                        "example": "JBSWY3DPEHPK3PXP"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/enable-2fa": {
+        "post": {
+          "summary": "Enable 2FA for the user",
+          "description": "This API enables 2FA for the user by verifying the OTP generated by their authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "token generated by the user's authenticator app",
+                      "example": 123456
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "2FA enabled successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Two-factor authentication enabled successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while enabling two-factor authentication."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Error message if OTP verification fails",
+                        "example": "Invalid OTP. Please try again."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while enabling two-factor authentication.",
+                    "error": "Invalid code or secret"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/verify-2fa": {
+        "post": {
+          "summary": "Verify 2FA OTP for sensitive information access",
+          "description": "This API is used to verify the OTP from the user's authenticator app for sensitive operations such as accessing confidential data.\nThis is a separate verification step and should be used whenever 2FA is required to access specific, sensitive information.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "The one-time password (OTP) sent to the user.",
+                      "example": "123456",
+                      "maxLength": 6,
+                      "minLength": 6
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Invalid OTP",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid OTP."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/status-2fa": {
+        "get": {
+          "summary": "Retrieve the 2FA status of the user",
+          "description": "This API returns the current 2FA status of the user, indicating whether 2FA is enabled or not.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA status retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "2FA Enabled for this user"
+                      },
+                      "status": {
+                        "type": "boolean",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/disable-2fa": {
+        "put": {
+          "summary": "Disable 2FA for the user",
+          "description": "This API disables 2FA for the user by verifying the OTP from the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA disabled successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "2FA disabled successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb": {
+        "post": {
+          "summary": "Initiate the application process for corporate customers",
+          "description": "This API is used to initiate the application process for corporate customers.\n\nWorkflow:\n- The API accepts the initial details required to start the corporate customer application.\n- Once initiated, the system assigns a unique application ID and marks the application as pending further inputs.\n\nKey Notes:\n- This process is specific to corporate customers.\n- The application will require further steps to complete, such as uploading documents, filling additional details, etc.\n- Notifications or progress updates will be sent to the user’s registered email or dashboard.\n\nUpon successful initiation:\n- The API returns the unique application ID and status.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "initialUser": {
+                      "type": "object",
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The initial user of the company",
+                          "properties": {
+                            "role": {
+                              "type": "string",
+                              "description": "This user's role at their company"
+                            },
+                            "walletAddress": {
+                              "type": "string",
+                              "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                            },
+                            "ipAddress": {
+                              "type": "string",
+                              "description": "The user's IP address"
+                            },
+                            "iovationBlackbox": {
+                              "type": "string",
+                              "description": "A blackbox string generated by the client side Iovation library"
+                            }
+                          },
+                          "required": [
+                            "iovationBlackbox",
+                            "ipAddress",
+                            "isTermsOfServiceAccepted"
+                          ]
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the company looking to create an account"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The company's physical address"
+                        }
+                      ]
+                    },
+                    "chainId": {
+                      "type": "string",
+                      "description": "the chain id of the company's external collateral contract"
+                    },
+                    "contractAddress": {
+                      "type": "string",
+                      "description": "the address of the company's external collateral contract;"
+                    },
+                    "entity": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    },
+                    "representatives": {
+                      "type": "array",
+                      "description": "The company's representatives",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    },
+                    "ultimateBeneficialOwners": {
+                      "type": "array",
+                      "description": "The company's ultimate beneficial owners",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "initialUser",
+                    "name",
+                    "address",
+                    "entity",
+                    "representatives",
+                    "ultimateBeneficialOwners"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information saved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "Indicates the form is in draft mode.",
+                        "example": "Pending",
+                        "enum": [
+                          "PENDING"
+                        ]
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "Message providing more information about the draft status.",
+                        "example": "KYB information saved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique ID for tracking the draft submission.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "ISO timestamp of the last update.",
+                        "example": "2024-10-14T12:34:56Z"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "General message about the validation error.",
+                        "example": "Validation Failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "The form field with the issue.",
+                              "example": "businessName"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Description of the validation error.",
+                              "example": "The business name is required."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/{id}": {
+        "get": {
+          "summary": "Retrieve corporate customer application details",
+          "description": "This API is used to fetch the details of an existing corporate customer application.\n       \nKey Notes:\n- Returns detailed information about the application, including the status and all submitted details.\n- If the `id` does not exist, the API will return an appropriate error message.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "KYB information retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A success message for the response.",
+                        "example": "KYB information retrieved successfully."
+                      },
+                      "kybData": {
+                        "type": "object",
+                        "description": "The KYB information retrieved for the company.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique ID of the KYB draft.",
+                            "example": "550e8400-e29b-41d4-a716-446655440000"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the company.",
+                            "example": "Acme Corp"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The company's physical address"
+                              }
+                            ]
+                          },
+                          "chainId": {
+                            "type": "string",
+                            "description": "the chain id of the company's external collateral contract"
+                          },
+                          "documents": {
+                            "type": "array",
+                            "description": "List of KYB documents.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "Name of the document",
+                                  "example": "passport_image.png"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                                  "example": "CERT_INC"
+                                },
+                                "side": {
+                                  "type": "string",
+                                  "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                                  "example": "front, back"
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                                  "example": "USA",
+                                  "maxLength": 3
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "entity": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The legal entity's name"
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "The legal entity's type - LLC, S Corp, etc."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "A brief description of the legal entity, and its activities"
+                              },
+                              "taxId": {
+                                "type": "string",
+                                "description": "The legal entity's national tax id"
+                              },
+                              "registrationNumber": {
+                                "type": "string",
+                                "description": "The legal entity's registration number"
+                              },
+                              "website": {
+                                "type": "string",
+                                "description": "The legal entity's website"
+                              },
+                              "expectedSpend": {
+                                "type": "string",
+                                "description": "How much the legal entity expects to spend each month"
+                              },
+                              "industry": {
+                                "type": "string",
+                                "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "taxId",
+                              "registrationNumber",
+                              "website"
+                            ]
+                          },
+                          "representatives": {
+                            "type": "array",
+                            "description": "List of company representatives.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "description": "The person's first name",
+                                  "maxLength": 50
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "description": "The person's last name",
+                                  "maxLength": 50
+                                },
+                                "birthDate": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The person's birth date"
+                                },
+                                "nationalId": {
+                                  "type": "string",
+                                  "description": "National ID (9-digit SSN for US users)"
+                                },
+                                "countryOfIssue": {
+                                  "type": "string",
+                                  "description": "2-letter country code where the ID was issued",
+                                  "maxLength": 2
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "The person's email address"
+                                },
+                                "address": {
+                                  "allOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "Auto-generated UUID for the document",
+                                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                        },
+                                        "line1": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "line2": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "city": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "maxLength": 60
+                                        },
+                                        "postalCode": {
+                                          "type": "string",
+                                          "maxLength": 15
+                                        },
+                                        "countryCode": {
+                                          "type": "string",
+                                          "maxLength": 2
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        }
+                                      },
+                                      "required": [
+                                        "line1",
+                                        "city",
+                                        "region",
+                                        "postalCode",
+                                        "countryCode",
+                                        "country"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "description": "The person's address"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "firstName",
+                                "lastName",
+                                "birthDate",
+                                "nationalId",
+                                "countryOfIssue",
+                                "email",
+                                "address"
+                              ]
+                            }
+                          },
+                          "ultimateBeneficialOwners": {
+                            "type": "array",
+                            "description": "List of the company's ultimate beneficial owners.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "description": "The person's first name",
+                                  "maxLength": 50
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "description": "The person's last name",
+                                  "maxLength": 50
+                                },
+                                "birthDate": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The person's birth date"
+                                },
+                                "nationalId": {
+                                  "type": "string",
+                                  "description": "National ID (9-digit SSN for US users)"
+                                },
+                                "countryOfIssue": {
+                                  "type": "string",
+                                  "description": "2-letter country code where the ID was issued",
+                                  "maxLength": 2
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "The person's email address"
+                                },
+                                "address": {
+                                  "allOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "Auto-generated UUID for the document",
+                                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                        },
+                                        "line1": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "line2": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "city": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "maxLength": 60
+                                        },
+                                        "postalCode": {
+                                          "type": "string",
+                                          "maxLength": 15
+                                        },
+                                        "countryCode": {
+                                          "type": "string",
+                                          "maxLength": 2
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        }
+                                      },
+                                      "required": [
+                                        "line1",
+                                        "city",
+                                        "region",
+                                        "postalCode",
+                                        "countryCode",
+                                        "country"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "description": "The person's address"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "firstName",
+                                "lastName",
+                                "birthDate",
+                                "nationalId",
+                                "countryOfIssue",
+                                "email",
+                                "address"
+                              ]
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "The current status of the KYB process.",
+                            "example": "Pending"
+                          },
+                          "referralCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "referralCount": {
+                            "type": "number",
+                            "example": 10
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message.",
+                        "example": "Error occurred while retrieving KYB information."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A detailed error message for troubleshooting.",
+                        "example": "KYB record not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update details of a corporate customer application",
+          "description": "This API is used to update the details of an existing corporate customer application.\n\nWorkflow:\n- Provide the unique application ID and the updated fields.\n- Only editable fields can be modified;\n\nKey Notes:\n- The application must exist in the system.\n- If the application is already submitted for review, updates will be restricted.\n\nUpon successful update:\n- The application details are updated, and the new data is stored in the system.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "initialUser": {
+                      "type": "object",
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The initial user of the company",
+                          "properties": {
+                            "role": {
+                              "type": "string",
+                              "description": "This user's role at their company"
+                            },
+                            "walletAddress": {
+                              "type": "string",
+                              "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                            },
+                            "ipAddress": {
+                              "type": "string",
+                              "description": "The user's IP address"
+                            },
+                            "iovationBlackbox": {
+                              "type": "string",
+                              "description": "A blackbox string generated by the client side Iovation library"
+                            }
+                          },
+                          "required": [
+                            "iovationBlackbox",
+                            "ipAddress",
+                            "isTermsOfServiceAccepted"
+                          ]
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the company looking to create an account"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The company's physical address"
+                        }
+                      ]
+                    },
+                    "chainId": {
+                      "type": "string",
+                      "description": "the chain id of the company's external collateral contract"
+                    },
+                    "contractAddress": {
+                      "type": "string",
+                      "description": "the address of the company's external collateral contract;"
+                    },
+                    "entity": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    },
+                    "representatives": {
+                      "type": "array",
+                      "description": "The company's representatives",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    },
+                    "ultimateBeneficialOwners": {
+                      "type": "array",
+                      "description": "The company's ultimate beneficial owners",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "initialUser",
+                    "name",
+                    "address",
+                    "entity",
+                    "representatives",
+                    "ultimateBeneficialOwners"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information saved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "Indicates the form is in draft mode.",
+                        "example": "Pending",
+                        "enum": [
+                          "PENDING"
+                        ]
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "Message providing more information about the draft status.",
+                        "example": "KYB information saved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique ID for tracking the draft submission.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "ISO timestamp of the last update.",
+                        "example": "2024-10-14T12:34:56Z"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Updation Not Allowed for Pending or Verified Users",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Updation not allowed for users with pending or verified status."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "patch": {
+          "summary": "Perform a partial update on a corporate customer application",
+          "description": "This API is used for partial updates to a corporate customer application.\nSpecifically, it allows removing **one representative** and/or **one ultimate beneficial owner (UBO)** from an existing application.\n\nWorkflow:\n- Provide the unique **id** along with a single **representative** or **ultimateBeneficialOwner** to be removed.\n\nKey Notes:\n- If the application is already submitted for review, updates will be restricted.\n- Only one **representative** and/or one **ultimateBeneficialOwner** can be removed at a time..\n- Fields provided in the request body will be removed only; other application details remain unaffected.\n- The API only removes existing entries. If a provided entry does not exist, the API will return an error.\n\nUpon successful update:\n- The specified entry (representative or UBO) is removed from the application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Partial update data to remove representatives or ultimate Beneficial Owners",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "representativeId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The ID of the representative to remove"
+                    },
+                    "uboId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The ID of the ultimate beneficial owner to remove *"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information updated successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "KYB information updated successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request - Invalid input or missing required fields.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message.",
+                        "example": "Error occurred while retrieving KYB information."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A detailed error message for troubleshooting.",
+                        "example": "KYB record not found."
+                      }
+                    }
+                  },
+                  "examples": {
+                    "representativeNotFound": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Representative not found"
+                      }
+                    },
+                    "uboNotFound": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Ultimate Beneficial Owner not found"
+                      }
+                    },
+                    "invalidData": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Invalid data provided"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/submit/{id}": {
+        "put": {
+          "summary": "Submit a corporate customer application for review",
+          "description": "This API is used to submit a corporate customer application for review after all verification steps are complete.\n\n**Workflow**:\n- Ensure the application contains all mandatory fields in the required format, including user information, company information, documents, UBOs, and representatives (if applicable).\n- After the required data is validated, the application will be submitted for internal review.\n\n**Key Notes**:\n- The application will be processed, and any missing or incorrect information will result in a validation error.\n- Once submitted, no further updates will be allowed unless the application is returned for revision.\n- The action finalizes the application and makes it ready for review by the designated team.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Terms of Service Agreement. The user must accept the terms before submitting the application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isTermsOfServiceAccepted": {
+                      "type": "boolean",
+                      "description": "Indicates whether the user has accepted the Terms of Service."
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Corporate customer application submitted successfully for review.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A message providing more information about the submission.",
+                        "example": "KYB form submitted successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request - Missing or invalid terms acceptance or incomplete application data.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "General message about the validation error.",
+                        "example": "Validation Failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "The form field with the issue.",
+                              "example": "businessName"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Description of the validation error.",
+                              "example": "The business name is required."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyc": {
+        "post": {
+          "summary": "Initiate the Customer KYC application",
+          "description": "This API initiates the Customer KYC application process for individual customers.\n\nWorkflow:\n- Accepts customer details such as name, email, and wallet address.\n- Starts the KYC process by registering the customer and assigning a unique KYC ID.\n- The application status is marked as pending until additional steps are completed.\n\nKey Notes:\n- This process is specific to individual customers.\n- The application may require further actions, such as identity verification, uploading documents, etc.\n- Updates regarding the application's progress will be sent to the customer's registered email.\n\nUpon successful initiation:\n- The API returns a success message along with the KYC application status and KYC ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYC"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "description": "The customer's first name",
+                      "example": "John",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The customer's last name",
+                      "example": "Doe",
+                      "maxLength": 50
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The customer's email address",
+                      "example": "john.doe@example.com"
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "address": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    "phoneCountryCode": {
+                      "type": "string",
+                      "description": "Customer country code",
+                      "example": 91,
+                      "maxLength": 3
+                    },
+                    "phoneNumber": {
+                      "type": "string",
+                      "description": "phoneNumber",
+                      "example": 9999999999,
+                      "maxLength": 15
+                    },
+                    "occupation": {
+                      "type": "string",
+                      "description": "occupation code fetched from master api",
+                      "example": "11-3011",
+                      "maxLength": 50
+                    },
+                    "annualSalary": {
+                      "type": "number",
+                      "description": "annualSalary",
+                      "example": 4000000
+                    },
+                    "accountPurpose": {
+                      "type": "string",
+                      "description": "accountPurpose",
+                      "example": "Investment",
+                      "maxLength": 15
+                    },
+                    "expectedMonthlySpend": {
+                      "type": "number",
+                      "description": "expectedMonthlySpend",
+                      "example": 10000
+                    },
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "The person's wallet address; required if using the hosted completion flow and a non-custodial solution, but not required otherwise",
+                      "example": "0x1234...abcd"
+                    },
+                    "isTermOfServiceAccepted": {
+                      "type": "boolean",
+                      "description": "is customer accepted all terms of service",
+                      "example": true
+                    },
+                    "isWalletOwner": {
+                      "type": "boolean",
+                      "description": "is customer owner of wallet address",
+                      "example": true
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "walletAddress",
+                    "address",
+                    "ipAddress",
+                    "isTermOfServiceAccepted"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYC application initiated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "Indicates the form is in draft mode.",
+                        "example": "Pending",
+                        "enum": [
+                          "PENDING"
+                        ]
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "Message providing more information about the draft status.",
+                        "example": "KYC application initiated successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique ID for tracking the draft submission.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "ISO timestamp of the last update.",
+                        "example": "2024-10-14T12:34:56Z"
+                      },
+                      "nextSteps": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "verificationLink": {
+                              "type": "object",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://app-kyc.xyz/kyc"
+                                },
+                                "params": {
+                                  "type": "object",
+                                  "properties": {
+                                    "userId": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                    },
+                                    "redirect": {
+                                      "type": "string",
+                                      "format": "url",
+                                      "example": "https://app-qa.pay.com/kycConfirmation"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Error message indicating the reason for failure",
+                        "example": "Unable to initiate KYC because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "The field that caused the validation error",
+                              "example": "walletAddress"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "The validation error message",
+                              "example": "walletAddress must be a valid address"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "missingField": {
+                      "summary": "Missing required field",
+                      "value": {
+                        "message": "Unable to initiate KYC because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "firstName",
+                            "message": "firstName is required"
+                          }
+                        ]
+                      }
+                    },
+                    "invalidEmail": {
+                      "summary": "Invalid email format",
+                      "value": {
+                        "message": "Unable to initiate KYC because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "email",
+                            "message": "email must be a valid email address"
+                          }
+                        ]
+                      }
+                    },
+                    "invalidWalletAddress": {
+                      "summary": "Invalid wallet address",
+                      "value": {
+                        "message": "Unable to initiate KYC because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "walletAddress",
+                            "message": "walletAddress must be a valid address"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyc/{id}": {
+        "get": {
+          "summary": "Retrieve Individual customer application details",
+          "description": "This API is used to fetch the details of an existing individual customer application.\n       \nKey Notes:\n- Returns detailed information about the application, including the status and all submitted details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYC"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "KYC information retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A success message for the response.",
+                        "example": "KYC information retrieved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The unique ID of the KYC draft.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The first name of the individual user.",
+                        "example": "John",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The last name of the individual user.",
+                        "example": "Doe",
+                        "maxLength": 50
+                      },
+                      "createdOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the user registers in the system.",
+                        "example": "2024-10-14T12:34:56Z"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address of the individual user.",
+                        "example": "johndoe@johndoe.com"
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "line1": {
+                            "type": "string",
+                            "description": "The first line of the address.",
+                            "example": "123, ABC Street",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "description": "The city of the address.",
+                            "example": "XYZ",
+                            "maxLength": 50
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "description": "The country code of the address.",
+                            "example": "IN",
+                            "maxLength": 2,
+                            "minLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "description": "The country of the address.",
+                            "example": "India",
+                            "maxLength": 50
+                          }
+                        }
+                      },
+                      "phoneCountryCode": {
+                        "type": "string",
+                        "description": "The country code of the phone number.",
+                        "example": "91",
+                        "maxLength": 3
+                      },
+                      "phoneNumber": {
+                        "type": "string",
+                        "description": "The phone number of the individual user.",
+                        "example": "1234567890",
+                        "maxLength": 15,
+                        "minLength": 1
+                      },
+                      "badge": {
+                        "type": "object",
+                        "description": "Badge earned by the user based on their activities in the system.",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Short code for the badge.",
+                            "example": "SupF"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Full name of the badge.",
+                            "example": "SuperFan"
+                          }
+                        }
+                      },
+                      "referralCode": {
+                        "type": "string",
+                        "example": "ABCD1234"
+                      },
+                      "referralDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.1
+                      },
+                      "referralDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "percentage",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "referralCount": {
+                        "type": "number",
+                        "example": 10
+                      },
+                      "referrerCode": {
+                        "type": "string",
+                        "example": "absdkfjhdsd"
+                      },
+                      "referrerDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 100
+                      },
+                      "referrerDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "flat",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "walletAddress": {
+                        "type": "string",
+                        "description": "The wallet address of the individual user.",
+                        "example": "0x1234567890abcdef1234567890abcdef12345678"
+                      },
+                      "nextSteps": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "verificationLink": {
+                              "type": "object",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://app-kyc.xyz/kyc"
+                                },
+                                "params": {
+                                  "type": "object",
+                                  "properties": {
+                                    "userId": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                    },
+                                    "redirect": {
+                                      "type": "string",
+                                      "format": "url",
+                                      "example": "https://app-qa.pay.com/kycConfirmation"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "pending": {
+                      "summary": "Pending status with next steps",
+                      "value": {
+                        "message": "KYC information retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "occupation": "Business",
+                        "annualSalary": 50000,
+                        "accountPurpose": "Investement",
+                        "expectedMonthlySpend": 10000,
+                        "walletAddress": "0x1234567890",
+                        "status": "pending",
+                        "referralCode": "ABCD1234",
+                        "nextSteps": [
+                          {
+                            "verificationLink": {
+                              "url": "https://www.example.com",
+                              "params": {
+                                "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                                "redirect": "https://app-qa.pay.com/kycConfirmation"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "approved": {
+                      "summary": "Approved status without next steps",
+                      "value": {
+                        "message": "KYC information retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "approved",
+                        "referralCode": "ABCD1234",
+                        "referralCount": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message.",
+                        "example": "Error occurred while retrieving KYC information."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A detailed error message for troubleshooting.",
+                        "example": "KYC record not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyc/submit/{id}": {
+        "put": {
+          "summary": "Submit a individual customer application for review",
+          "description": "This API is used to submit an individual customer application for review after all verification steps are complete.\n        \n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYC"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "KYC information submitted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "KYC information submitted successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyc/profile": {
+        "get": {
+          "summary": "Retrieve the customer profile details",
+          "description": "This API returns the profile information of the authenticated customer.\n- Returns information related to the customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYC"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved user profile",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A success message for the response.",
+                        "example": "KYC information retrieved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The unique ID of the KYC draft.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The first name of the individual user.",
+                        "example": "John",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The last name of the individual user.",
+                        "example": "Doe",
+                        "maxLength": 50
+                      },
+                      "createdOn": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The date and time when the user registers in the system.",
+                        "example": "2024-10-14T12:34:56Z"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address of the individual user.",
+                        "example": "johndoe@johndoe.com"
+                      },
+                      "address": {
+                        "type": "object",
+                        "properties": {
+                          "line1": {
+                            "type": "string",
+                            "description": "The first line of the address.",
+                            "example": "123, ABC Street",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "description": "The city of the address.",
+                            "example": "XYZ",
+                            "maxLength": 50
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "description": "The country code of the address.",
+                            "example": "IN",
+                            "maxLength": 2,
+                            "minLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "description": "The country of the address.",
+                            "example": "India",
+                            "maxLength": 50
+                          }
+                        }
+                      },
+                      "phoneCountryCode": {
+                        "type": "string",
+                        "description": "The country code of the phone number.",
+                        "example": "91",
+                        "maxLength": 3
+                      },
+                      "phoneNumber": {
+                        "type": "string",
+                        "description": "The phone number of the individual user.",
+                        "example": "1234567890",
+                        "maxLength": 15,
+                        "minLength": 1
+                      },
+                      "badge": {
+                        "type": "object",
+                        "description": "Badge earned by the user based on their activities in the system.",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Short code for the badge.",
+                            "example": "SupF"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Full name of the badge.",
+                            "example": "SuperFan"
+                          }
+                        }
+                      },
+                      "referralCode": {
+                        "type": "string",
+                        "example": "ABCD1234"
+                      },
+                      "referralDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.1
+                      },
+                      "referralDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "percentage",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "referralCount": {
+                        "type": "number",
+                        "example": 10
+                      },
+                      "referrerCode": {
+                        "type": "string",
+                        "example": "absdkfjhdsd"
+                      },
+                      "referrerDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 100
+                      },
+                      "referrerDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "flat",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "walletAddress": {
+                        "type": "string",
+                        "description": "The wallet address of the individual user.",
+                        "example": "0x1234567890abcdef1234567890abcdef12345678"
+                      },
+                      "nextSteps": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "verificationLink": {
+                              "type": "object",
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://app-kyc.xyz/kyc"
+                                },
+                                "params": {
+                                  "type": "object",
+                                  "properties": {
+                                    "userId": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                    },
+                                    "redirect": {
+                                      "type": "string",
+                                      "format": "url",
+                                      "example": "https://app-qa.pay.com/kycConfirmation"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "individualPending": {
+                      "summary": "Individual customer profile with pending status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "occupation": "Business",
+                        "annualSalary": 50000,
+                        "accountPurpose": "Investement",
+                        "expectedMonthlySpend": 10000,
+                        "walletAddress": "0x1234567890",
+                        "status": "pending",
+                        "referralCode": "ABCD1234",
+                        "referrerCode": "AXCY5678",
+                        "nextSteps": [
+                          {
+                            "verificationLink": {
+                              "url": "https://www.example.com",
+                              "params": {
+                                "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                                "redirect": "https://app-qa.pay.com/kycConfirmation"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "individualapproved": {
+                      "summary": "Individual customer profile with approved status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "approved",
+                        "referralCode": "ABCD1234",
+                        "referralDiscount": 0.1,
+                        "referralDiscountType": "percentage",
+                        "referralCount": 10,
+                        "referrerCode": "AXCY5678",
+                        "referrerDiscount": 100,
+                        "referrerDiscountType": "flat",
+                        "badge": {
+                          "code": "SupF",
+                          "name": "SuperFan"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message for the failed profile retrieval.",
+                        "example": "Error occurred while retrieving the profile."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information to assist in troubleshooting.",
+                        "example": "Profile not found."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while fetching user profile.",
+                    "error": "User not found"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/log": {
+        "post": {
+          "summary": "Submit Logs",
+          "description": "Endpoint to submit logs from a mobile device\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Log"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Detailed log message describing the event or error.",
+                      "example": "An error occurred while processing the request."
+                    },
+                    "logLevel": {
+                      "type": "string",
+                      "description": "Severity level of the log. Common levels include INFO, WARN, ERROR, DEBUG.",
+                      "example": "ERROR",
+                      "enum": [
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "DEBUG"
+                      ]
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Specific type or category of the log. Examples include RuntimeError, ValidationError, NetworkError.",
+                      "example": "RuntimeError",
+                      "enum": [
+                        "RuntimeError",
+                        "ValidationError",
+                        "NetworkError"
+                      ]
+                    },
+                    "stack": {
+                      "type": "string",
+                      "description": "Stack trace of the error, providing detailed information about where the error occurred.",
+                      "example": "Error: An error occurred at ..."
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "URL of the request that generated the log. This can be any component URL if the logging comes from a mobile device.",
+                      "example": "https://api.example.com/resource"
+                    },
+                    "deviceDetail": {
+                      "type": "object",
+                      "properties": {
+                        "sysName": {
+                          "type": "string",
+                          "description": "The name of the operating system on the device.",
+                          "example": "android"
+                        },
+                        "sysVersion": {
+                          "type": "string",
+                          "description": "The version of the operating system on the device.",
+                          "example": "14"
+                        }
+                      },
+                      "required": [
+                        "sysName",
+                        "sysVersion"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "logLevel",
+                    "stack",
+                    "url",
+                    "sysName",
+                    "sysVersion"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Log submitted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Log submitted successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid request payload."
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "logLevel"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "logLevel is required."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/masterdata/{type}": {
+        "get": {
+          "summary": "Get master data by type",
+          "description": "Retrieve the list of master data by type. Supported types:\n  - **Country**: Returns a list of countries with codes and names.\n  - **DocumentType**: Returns document types available in the system.\n  - **DepositToken**: Returns a list of tokens associated with blockchains.\n  - **CardStatus**: Returns status information for various card types.\n  - **CardProduct**: Returns card product types available in the system.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Master Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "path",
+              "description": "Type of master data to retrieve (e.g., **Country**, **DepositToken**, **CardStatus**, **UserRole**, **CardProduct**, **Consent**).",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "Country",
+                  "DocumentType",
+                  "DepositToken",
+                  "CardStatus",
+                  "UserRole",
+                  "CardProduct",
+                  "Consent"
+                ]
+              }
+            },
+            {
+              "name": "keyType",
+              "in": "query",
+              "description": "Optional key type to filter the master data.",
+              "required": false,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of master data by type",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "description": "Response when type is `Country`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "country_name": {
+                              "type": "string"
+                            },
+                            "country_code": {
+                              "type": "string"
+                            },
+                            "country_code_alpha3": {
+                              "type": "string"
+                            },
+                            "country_mobile_code": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `DocumentType`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "isActive": {
+                              "type": "boolean"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `DepositToken`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "chainId": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "logo": {
+                              "type": "string"
+                            },
+                            "tokens": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  },
+                                  "address": {
+                                    "type": "string"
+                                  },
+                                  "logo": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `CardStatus`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "isActive": {
+                              "type": "boolean"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `CardProduct`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "scheme": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fees": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "coolOffPeriod": {
+                                    "type": "number",
+                                    "description": "Number of days for cooling off period"
+                                  },
+                                  "frequency": {
+                                    "type": "string",
+                                    "description": "Frequency of the fee",
+                                    "enum": [
+                                      "one-time",
+                                      "recurring"
+                                    ]
+                                  },
+                                  "interval": {
+                                    "type": "string",
+                                    "description": "Interval of the fee",
+                                    "enum": [
+                                      "lifetime",
+                                      "monthly",
+                                      "yearly"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "cardMaterial": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "fees": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "number"
+                                      },
+                                      "coolOffPeriod": {
+                                        "type": "number"
+                                      },
+                                      "frequency": {
+                                        "type": "string",
+                                        "enum": [
+                                          "one-time",
+                                          "recurring"
+                                        ]
+                                      },
+                                      "interval": {
+                                        "type": "string",
+                                        "enum": [
+                                          "none",
+                                          "lifetime",
+                                          "monthly",
+                                          "yearly"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "examples": {
+                    "Country": {
+                      "summary": "Example response for Country type",
+                      "value": [
+                        {
+                          "country_name": "Dummyland",
+                          "country_code": "DL",
+                          "country_code_alpha3": "DUM",
+                          "country_mobile_code": "76"
+                        },
+                        {
+                          "country_name": "Testistan",
+                          "country_code": "TS",
+                          "country_code_alpha3": "TST",
+                          "country_mobile_code": "56"
+                        },
+                        {
+                          "country_name": "Mockland",
+                          "country_code": "ML",
+                          "country_code_alpha3": "MOK",
+                          "country_mobile_code": "35"
+                        }
+                      ]
+                    },
+                    "DocumentType": {
+                      "summary": "Example response for DocumentType",
+                      "value": [
+                        {
+                          "type": "DocumentType",
+                          "key": "MOCK_ID",
+                          "value": "Mock Identification",
+                          "isActive": true,
+                          "id": "11111111-1111-1111-1111-111111111111"
+                        },
+                        {
+                          "type": "DocumentType",
+                          "key": "TEST_DOC",
+                          "value": "Test Document",
+                          "isActive": true,
+                          "id": "22222222-2222-2222-2222-222222222222"
+                        },
+                        {
+                          "type": "DocumentType",
+                          "key": "DUMMY_CERT",
+                          "value": "Dummy Certificate",
+                          "isActive": false,
+                          "id": "33333333-3333-3333-3333-333333333333"
+                        }
+                      ]
+                    },
+                    "DepositToken": {
+                      "summary": "Example response for DepositToken",
+                      "value": [
+                        {
+                          "chainId": 99999,
+                          "name": "Test Chain Network",
+                          "logo": "https://example.com/test-chain.png",
+                          "tokens": [
+                            {
+                              "name": "Test Coin",
+                              "symbol": "TEST",
+                              "address": "0x1111111111111111111111111111111111111111",
+                              "logo": "https://example.com/test-coin.png"
+                            },
+                            {
+                              "name": "Mock Token",
+                              "symbol": "MOCK",
+                              "address": "0x2222222222222222222222222222222222222222",
+                              "logo": "https://example.com/mock-token.png"
+                            }
+                          ]
+                        },
+                        {
+                          "chainId": 88888,
+                          "name": "Mock Chain Network",
+                          "logo": "https://example.com/mock-chain.png",
+                          "tokens": [
+                            {
+                              "name": "Dummy Coin",
+                              "symbol": "DUMMY",
+                              "address": "0x3333333333333333333333333333333333333333",
+                              "logo": "https://example.com/dummy-coin.png"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "CardStatus": {
+                      "summary": "Example response for CardStatus",
+                      "value": [
+                        {
+                          "type": "CardStatus",
+                          "key": "test_status",
+                          "value": "Test Status",
+                          "isActive": true,
+                          "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                        },
+                        {
+                          "type": "CardStatus",
+                          "key": "mock_status",
+                          "value": "Mock Status",
+                          "isActive": true,
+                          "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                        },
+                        {
+                          "type": "CardStatus",
+                          "key": "dummy_status",
+                          "value": "Dummy Status",
+                          "isActive": false,
+                          "id": "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                        }
+                      ]
+                    },
+                    "CardProductType": {
+                      "summary": "Example response for Card Product",
+                      "value": [
+                        {
+                          "type": "PLATINUM",
+                          "scheme": "VISA",
+                          "code": "ABCD1234",
+                          "label": "Platinum Rewards Card",
+                          "description": "Earn 2x points on every purchase",
+                          "fees": [
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                              "type": "activation",
+                              "label": "Joining Fees",
+                              "amount": 49900,
+                              "coolOffPeriod": 30,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            },
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                              "type": "rental",
+                              "label": "Monthly Fees",
+                              "amount": 25900,
+                              "coolOffPeriod": 31,
+                              "frequency": "recurring",
+                              "interval": "monthly"
+                            },
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                              "type": "rental",
+                              "label": "Yearly Fees",
+                              "amount": 99900,
+                              "coolOffPeriod": 31,
+                              "frequency": "recurring",
+                              "interval": "yearly"
+                            }
+                          ],
+                          "cardMaterial": [
+                            {
+                              "code": "metal",
+                              "name": "Metal",
+                              "fees": {
+                                "id": "79e9a063-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            },
+                            {
+                              "code": "semi-metal",
+                              "name": "Semi-metal",
+                              "fees": {
+                                "id": "c0566eee-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            },
+                            {
+                              "code": "plastic",
+                              "name": "Plastic",
+                              "fees": {
+                                "id": "78a54dc0-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "Consent": {
+                      "summary": "Example response for Consent",
+                      "value": [
+                        {
+                          "id": "3c9faeb4-30fc-4bbf-8890-e8beec565407",
+                          "type": "signup",
+                          "message": "I accept the Consent",
+                          "isMandatory": true,
+                          "isActive": true
+                        },
+                        {
+                          "id": "8217bf6b-bc1c-4272-864f-bc721e3d1771",
+                          "type": "signup",
+                          "message": "I certify that the information.",
+                          "isMandatory": true,
+                          "isActive": true
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request - Invalid master data type",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid master data type"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/masterdata/occupation": {
+        "get": {
+          "summary": "Get consumer occupations or corporate industry",
+          "description": "Retrieve a list of consumer occupations or corporate industry.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Master Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "description": "Partner code associated with the request.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "description": "Application code for validating mobile requests.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK - A list of matching consumer occupations.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "Represents a consumer occupation entry.",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "description": "Unique code identifier for the occupation.",
+                          "example": "11-3011"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the occupation.",
+                          "example": "Administrative Services Managers"
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                          "description": "Indicates if the occupation record is currently active.",
+                          "example": true
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "name",
+                        "isActive"
+                      ]
+                    }
+                  },
+                  "example": [
+                    {
+                      "code": "11-3011",
+                      "name": "Administrative Services Managers",
+                      "isActive\"": true
+                    },
+                    {
+                      "code": "11-2011",
+                      "name": "Advertising and Promotions Managers",
+                      "isActive": true
+                    },
+                    {
+                      "code": "13-1011",
+                      "name": "Agents and Business Managers of Artists, Performer",
+                      "isActive": true
+                    }
+                  ]
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/notification": {
+        "get": {
+          "summary": "Get notifications",
+          "description": "Retrieve the list of notifications for the user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Notification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved notifications",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "notifications": {
+                        "type": "array",
+                        "description": "List of user notifications",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Your profile has been updated."
+                            },
+                            "date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2024-10-11T12:00:00Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while fetching notifications."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Unable to retrieve notifications"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while fetching notifications.",
+                    "error": "Unable to retrieve notifications"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/notification/{id}": {
+        "put": {
+          "summary": "Update notification",
+          "description": "Update the read status of a notification.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Notification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the notification to update",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean",
+                      "description": "Whether the notification is read or not",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Notification updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Notification updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while fetching notifications."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Unable to retrieve notifications"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while updating notification.",
+                    "error": "Notification not found"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/create-password": {
+        "post": {
+          "summary": "Create a password for the user after email verification",
+          "description": "This API allows the user to set their password after successfully verifying their email. \nThe user must provide the following details:\n- The **temporary token** received after successful email verification.\n- A new password that will be used to authenticate the user on future logins.\n\nUpon successful creation of the password:\n- The user’s password is saved securely in the system.\n- The account is fully activated, and the user can log in using their new password.\n\nIf the temporary token is invalid or expired:\n- The user will receive an error response indicating the failure.\n- The password creation process will be aborted.\n\nIf the password doesn't meet the required security criteria:\n- The user will be prompted to choose a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "password": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message",
+                        "example": "Password created successfully. You can now sign in."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to create a password. Please ensure your token is valid and try again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                        "example": "weak password"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/change-password": {
+        "post": {
+          "summary": "Change the user’s password",
+          "description": "This API allows an authenticated user to change their existing password.\n\nRequirements:\n- The user must provide their current password for verification.\n- A new password that meets the system's security criteria must be provided.\n\nUpon successful password change:\n- The new password will replace the existing password.\n- The user can use the new password for future logins.\n\nIf the current password is incorrect:\n- The user will receive an error response, and the password will not be updated.\n\nIf the new password does not meet security criteria:\n- The user will be prompted to provide a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "oldPassword": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The user's current password",
+                      "example": "oldpassword123"
+                    },
+                    "newPassword": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "oldPassword",
+                    "newPassword"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password changed successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password changed successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while changing password."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Old password is incorrect"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    },
+                    "IncorrectOldPassword": {
+                      "summary": "Incorrect Old Password",
+                      "value": {
+                        "message": "Old password is incorrect.",
+                        "error": "Incorrect Old Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/forgot-password": {
+        "post": {
+          "summary": "Initiate the password reset process",
+          "description": "This API allows a user to request a password reset link or token if they have forgotten their password.\n\nWorkflow:\n- The user provides their registered email address.\n- If the email exists in the system:\n  - A password reset link or token is sent to the provided email.\n  - The user can use this link/token to reset their password.\n- If the email does not exist:\n  - For security purposes, a generic success message is returned (to prevent email enumeration).\n\nThe email will contain:\n- A secure token.\n- Instructions to reset the password.\n\nIf the email sending fails:\n- An error response will be provided.\n\nUpon successful email delivery, the user will receive a confirmation response.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's registered email address",
+                      "example": "user@example.com"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset link sent",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password reset link sent to your email."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while sending password reset link."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "User not found"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while sending password reset link.",
+                    "error": "User not found"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/reset-password": {
+        "post": {
+          "summary": "Reset user password using a valid reset token",
+          "description": "This API allows a user to reset their password using the password reset token received in the password reset email.\nWorkflow:\n- The user provides:\n  - A valid password reset token.\n  - A new password that meets the system’s security criteria.\n- If the token is valid and not expired:\n  - The user's password is securely updated in the system.\n  - The token is invalidated to prevent reuse.\n- If the token is invalid or expired:\n  - An error response is returned.\n\nUpon successful password reset:\n- The user will be able to log in with the new password.\n\nSecurity Considerations:\n- The reset token must be validated for authenticity and expiration.\n- The new password should meet all required security criteria.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "password": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password reset successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to create a password. Please ensure your token is valid and try again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                        "example": "weak password"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/profile": {
+        "get": {
+          "summary": "Retrieve the customer profile details",
+          "description": "This API returns the profile information of the authenticated customer.\n- Returns information related to the customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved user profile",
+              "content": {
+                "application/json": {
+                  "schema": {},
+                  "examples": {
+                    "corporate": {
+                      "summary": "Corporate customer profile",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "name": "Company Name",
+                        "status": "pending",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "line2": "DEF Area",
+                          "city": "XYZ",
+                          "region": "Region",
+                          "postalCode": "123456",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "company": {
+                          "name": "Entity Name",
+                          "type": "Entity Type",
+                          "description": "Entity Description",
+                          "taxId": "1234567890",
+                          "registrationNumber": "1234567890",
+                          "website": "https://www.example.com",
+                          "expectedSpend": 123456
+                        },
+                        "documents": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "name": "Document Name",
+                            "type": "Document Type",
+                            "side": "Document Side",
+                            "country": "Document Country",
+                            "size": 123456
+                          }
+                        ],
+                        "representatives": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "firstName": "Representative Name",
+                            "lastName": "Representative Last Name",
+                            "birthDate": "1990-01-01",
+                            "nationalId": "1234567890",
+                            "countryOfIssue": "IN",
+                            "email": "representative@rep.com",
+                            "address": {
+                              "line1": "123, ABC Street",
+                              "line2": "DEF Area",
+                              "city": "XYZ",
+                              "region": "Region",
+                              "postalCode": "123456",
+                              "countryCode": "IN",
+                              "country": "India"
+                            }
+                          }
+                        ],
+                        "ultimateBeneficialOwners": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "firstName": "UBO Name",
+                            "lastName": "UNO Last Name",
+                            "birthDate": "1990-01-01",
+                            "nationalId": "1234567890",
+                            "countryOfIssue": "IN",
+                            "email": "ubo@ubo.com",
+                            "address": {
+                              "line1": "123, ABC Street",
+                              "line2": "DEF Area",
+                              "city": "XYZ",
+                              "region": "Region",
+                              "postalCode": "123456",
+                              "countryCode": "IN",
+                              "country": "India"
+                            }
+                          }
+                        ],
+                        "user": {
+                          "firstName": "User Name",
+                          "lastName": "User Last Name",
+                          "birthDate": "1990-01-01",
+                          "nationalId": "1234567890",
+                          "countryOfIssue": "IN",
+                          "email": "user@user.com",
+                          "address": {
+                            "line1": "123, ABC Street",
+                            "line2": "DEF Area",
+                            "city": "XYZ",
+                            "region": "Region",
+                            "postalCode": "123456",
+                            "countryCode": "IN",
+                            "country": "India"
+                          },
+                          "walletAddress": "0x1234567890",
+                          "ipAddresse": "0.0.0.0",
+                          "iovationBlackBox": "1234567890"
+                        },
+                        "referralCode": "ABCD1234",
+                        "referralCount": 10
+                      }
+                    },
+                    "individualPending": {
+                      "summary": "Individual customer profile with pending status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "pending",
+                        "nextSteps": [
+                          {
+                            "verificationLink": {
+                              "url": "https://www.example.com",
+                              "params": {
+                                "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "individualapproved": {
+                      "summary": "Individual customer profile with approved status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "approved"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message for the failed profile retrieval.",
+                        "example": "Error occurred while retrieving the profile."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information to assist in troubleshooting.",
+                        "example": "Profile not found."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while fetching user profile.",
+                    "error": "User not found"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/transaction": {
+        "get": {
+          "summary": "Get transactions",
+          "description": "This API returns transaction details. \n- Returns transaction details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Transactions"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "Page number",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Number of items per page",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "description": "Sort field",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "date",
+                  "amount"
+                ]
+              }
+            },
+            {
+              "name": "sortDirection",
+              "in": "query",
+              "description": "Sort direction",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Transaction type",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "spend",
+                  "deposit",
+                  "refund"
+                ]
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "description": "Transaction status",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "merchantName",
+              "in": "query",
+              "description": "Merchant name",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Transactions fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "67a21ce9971b27fea38169e3"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "spend"
+                            },
+                            "status": {
+                              "type": "string",
+                              "example": "completed"
+                            },
+                            "merchantName": {
+                              "type": "string",
+                              "example": "zomoto"
+                            },
+                            "date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-02-04T04:59:17.272Z"
+                            },
+                            "amount": {
+                              "type": "number",
+                              "example": 100
+                            },
+                            "currency": {
+                              "type": "string",
+                              "example": "usd"
+                            },
+                            "localAmount": {
+                              "type": "number",
+                              "example": 100
+                            },
+                            "localCurrency": {
+                              "type": "string",
+                              "example": "usd"
+                            }
+                          }
+                        }
+                      },
+                      "totalTransactions": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalSpent": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "totalReceived": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "totalBalance": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "page": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 1
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/transaction/{id}": {
+        "get": {
+          "summary": "Get transaction detail",
+          "description": "Fetches details of a specific transaction.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Transactions"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique identifier of the transaction.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "17389431-9fb7-4689-a15b-c799f5cacb63"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Transaction fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Transaction fetched successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "example": "173894319fb74689"
+                      },
+                      "from": {
+                        "type": "string",
+                        "example": "Abcd"
+                      },
+                      "card": {
+                        "type": "string",
+                        "example": "1234"
+                      },
+                      "type": {
+                        "type": "string",
+                        "example": "spend"
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "completed"
+                      },
+                      "to": {
+                        "type": "string",
+                        "example": "test"
+                      },
+                      "date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2024-12-14T04:54:57.326Z"
+                      },
+                      "amount": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "currency": {
+                        "type": "string",
+                        "example": "usd"
+                      },
+                      "localAmount": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "localCurrency": {
+                        "type": "string",
+                        "example": "usd"
+                      },
+                      "transactionHash": {
+                        "type": "string",
+                        "example": "0x15189e46823bb"
+                      },
+                      "depositAddress": {
+                        "type": "string",
+                        "example": "0x15189e46823bb"
+                      },
+                      "chain": {
+                        "type": "string",
+                        "example": "Polygon (137)"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "spendTransaction": {
+                      "summary": "Transaction Spent",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "Abcd",
+                        "card": "1234",
+                        "type": "spend",
+                        "status": "completed",
+                        "to": "test",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "localAmount": 100,
+                        "localCurrency": "usd"
+                      }
+                    },
+                    "refundTransaction": {
+                      "summary": "Transaction Refund",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "test",
+                        "card": "1234",
+                        "type": "refund",
+                        "status": "completed",
+                        "to": "Abcd",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "localAmount": 100,
+                        "localCurrency": "usd"
+                      }
+                    },
+                    "depositTransaction": {
+                      "summary": "Transaction Deposit",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "0x15189e46823bb",
+                        "to": "On-Chain",
+                        "type": "deposit",
+                        "depositAddress": "0x15189e46823bb",
+                        "chain": "Polygon (137)",
+                        "status": "completed",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "transactionHash": "0x15189e46823bb"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Transaction detail not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Transaction detail not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/upload/{id}": {
+        "post": {
+          "summary": "Upload a document for a customer application",
+          "description": "This API allows uploading documents for a customer application.\n- Provide the application ID and upload a document related to the customer.\n- Ensure the document is of an allowed format (e.g., PDF, JPG, JPEG, PNG).\n- The document must be relevant to the application (e.g., identification proof, financial documents).\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID for the document",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "document": {
+                      "type": "string",
+                      "format": "binary",
+                      "description": "The file to be uploaded"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the document.",
+                      "example": "passport.pdf"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "CERT_INC",
+                        "COMP_REG",
+                        "SH_REG",
+                        "M_REG",
+                        "PASSPORT",
+                        "DL",
+                        "NATIONALID"
+                      ]
+                    },
+                    "side": {
+                      "type": "string",
+                      "enum": [
+                        "FRONT",
+                        "BACK"
+                      ]
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "The country associated with the document.",
+                      "example": "USA",
+                      "maxLength": 3,
+                      "minLength": 3
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Document uploaded successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A message about the success of the upload.",
+                        "example": "Document uploaded successfully"
+                      },
+                      "documentId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The id of the uploaded file.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid input or upload error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "The HTTP status code.",
+                        "example": 400
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A short description of the error.",
+                        "example": "Invalid file type"
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "A detailed message about the error.",
+                        "example": "Only PDF, JPEG, JPG, and PNG file types are allowed."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/upload/{id}/{documentId}": {
+        "get": {
+          "summary": "Retrieve a specific document as a binary file",
+          "description": "This API retrieves a file associated with a customer application, identified by the **id** (customer application ID) and **documentId**.\n- The document is returned as a binary file (blob).\n- The file is available for download or direct streaming depending on your use case.\n- Ensure both **id** and **documentId** are valid to retrieve the correct document.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID to which the document belongs.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "documentId",
+              "in": "path",
+              "description": "The ID of the document to be deleted.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "File retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "File retrieved successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Document not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "error": {
+                        "type": "string",
+                        "example": "File not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "delete": {
+          "summary": "Delete a document associated with a customer application",
+          "description": "This API deletes a specific document related to the customer application, identified by the provided **id** and **documentId**.\n- Ensure the correct **id** (customer application ID) and `documentId` are provided.\n- The document will be permanently removed from the system.\n- This operation is irreversible.\n- A success message is returned if the document is successfully deleted, otherwise, appropriate error messages will be shown.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID to which the document belongs.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "documentId",
+              "in": "path",
+              "description": "The ID of the document to be deleted.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Document deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "File deleted successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Document not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "error": {
+                        "type": "string",
+                        "example": "File not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user": {
+        "get": {
+          "summary": "Get all users",
+          "description": "Retrieve a list of all users, with optional filters for search, pagination, and specific user ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "The page number for pagination (default is 1).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "1"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "The number of items per page for pagination (default is 10).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "10"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "Search users by first name, last name, or email.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "John"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of users retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "List of users retrieved successfully"
+                      },
+                      "users": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "04e73427-5c71-44f3-bf7c-4e36c21f876c"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "example": "Test"
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "example": "QA"
+                            },
+                            "email": {
+                              "type": "string",
+                              "example": "test11@tdddest.com"
+                            },
+                            "roleCode": {
+                              "type": "string",
+                              "example": "EMPLOYEE"
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "example": "2001-10-10"
+                            },
+                            "status": {
+                              "type": "string",
+                              "example": "pending",
+                              "enum": [
+                                "approved",
+                                "rejected",
+                                "pending"
+                              ]
+                            },
+                            "cardIssued": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        }
+                      },
+                      "totalItems": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "page": {
+                        "type": "string",
+                        "example": "1"
+                      },
+                      "limit": {
+                        "type": "string",
+                        "example": "10"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No users found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "No users found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Create a new user",
+          "description": "Create a new user with the provided details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "User creation details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "example": "Doe"
+                    },
+                    "email": {
+                      "type": "string",
+                      "example": "john.doe@example.com"
+                    },
+                    "roleCode": {
+                      "type": "string",
+                      "example": "EMPLOYEE"
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "example": "2001-10-10"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User created successfully"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "example": "Doe"
+                          },
+                          "email": {
+                            "type": "string",
+                            "example": "john.doe@example.com"
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "example": "2001-10-10"
+                          },
+                          "roleCode": {
+                            "type": "string",
+                            "example": "EMPLOYEE"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "approved",
+                            "enum": [
+                              "approved",
+                              "rejected",
+                              "pending"
+                            ]
+                          },
+                          "cardIssued": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "roleCode"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "roleCode is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "summary": "Customer Not Found",
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "validationFailure": {
+                      "summary": "Validation Error",
+                      "value": {
+                        "message": "Unable to save user because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "roleCode",
+                            "message": "roleCode is required"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate is required"
+                          }
+                        ]
+                      }
+                    },
+                    "dateOfBirthValidationError": {
+                      "summary": "Date of Birth Validation Error",
+                      "value": {
+                        "message": "Unable to save user because of the birth validation failures",
+                        "errors": [
+                          {
+                            "field": "birthDate",
+                            "message": "Birth date must be after 1900-01-01"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate must be yyyy-mm-dd format"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "User must be at least 18 years old"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate must be a valid date"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}": {
+        "get": {
+          "summary": "Get user by ID",
+          "description": "Retrieve detailed information about a specific user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to retrieve",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User details retrieved successfully"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "example": "Doe"
+                          },
+                          "email": {
+                            "type": "string",
+                            "example": "john.doe@example.com"
+                          },
+                          "roleCode": {
+                            "type": "string",
+                            "example": "EMPLOYEE"
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "example": "2001-10-10"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "approved",
+                            "enum": [
+                              "approved",
+                              "rejected",
+                              "pending"
+                            ]
+                          },
+                          "cardIssued": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update user details",
+          "description": "Modify specific details of a user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to update",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "User update details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "example": "Doe"
+                    },
+                    "email": {
+                      "type": "string",
+                      "example": "john.doe@example.com"
+                    },
+                    "roleCode": {
+                      "type": "string",
+                      "example": "EMPLOYEE"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User updated successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "roleCode"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "roleCode is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    },
+                    "validationFailure": {
+                      "value": {
+                        "message": "Unable to save user because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "roleCode",
+                            "message": "roleCode is required"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate cannot be updated"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "delete": {
+          "summary": "Delete a user",
+          "description": "Delete a specific user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to delete",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User deleted successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/verification/status": {
+        "get": {
+          "summary": "Retrieve the verification status of a customer application",
+          "description": "This API retrieves the verification status of customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Verification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved the customer application verification status",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "pending",
+                        "enum": [
+                          "notStarted",
+                          "pending",
+                          "pendingEmailVerification",
+                          "emailVerified",
+                          "saved",
+                          "needsVerification",
+                          "verificationPending",
+                          "underReview",
+                          "manualReview",
+                          "needsInformation",
+                          "verified",
+                          "rejected",
+                          "cancelled",
+                          "denied",
+                          "locked"
+                        ]
+                      }
+                    }
+                  },
+                  "examples": {
+                    "corporatePending": {
+                      "summary": "Corporate Customer Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "corporateUnderReview": {
+                      "summary": "Corporate Customer Under Review Status",
+                      "value": {
+                        "status": "underReview"
+                      }
+                    },
+                    "corporateVerified": {
+                      "summary": "Corporate Customer Verified Status",
+                      "value": {
+                        "status": "verified"
+                      }
+                    },
+                    "individualPending": {
+                      "summary": "Individual Customer Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "individualPendingEmailVerification": {
+                      "summary": "Individual Customer Pending Email Verification Status",
+                      "value": {
+                        "status": "pendingEmailVerification"
+                      }
+                    },
+                    "individualEmailVerified": {
+                      "summary": "Individual Customer Email Verified Status",
+                      "value": {
+                        "status": "emailVerified"
+                      }
+                    },
+                    "individualSaved": {
+                      "summary": "Individual Customer Saved Status",
+                      "value": {
+                        "status": "saved"
+                      }
+                    },
+                    "individualVerificationPending": {
+                      "summary": "Individual Customer Verification Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "individualUnderReview": {
+                      "summary": "Individual Customer Under Review Status",
+                      "value": {
+                        "status": "underReview"
+                      }
+                    },
+                    "individualVerified": {
+                      "summary": "Individual Customer Verified Status",
+                      "value": {
+                        "status": "verified"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Status not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "example": "MISSING_INFORMATION"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Additional business details required."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Status not found.",
+                    "error": "Invalid request"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/deposit": {
+        "get": {
+          "summary": "Retrieve deposit information for the customer",
+          "description": "This API returns deposit details for the authenticated customer.\n- Returns deposits made under the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Deposit information retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chainId": {
+                          "type": "number"
+                        },
+                        "proxyAddress": {
+                          "type": "string"
+                        },
+                        "proxyAddressQrCode": {
+                          "type": "string",
+                          "description": "QR code image data for proxyAddress",
+                          "example": "data:image/png;base64,iVBORw0..."
+                        },
+                        "tokens": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Deposit information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Deposit information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/balance": {
+        "get": {
+          "summary": "Retrieve wallet balance for the customer",
+          "description": "This API returns the current wallet balance for the authenticated customer. The response includes:\n  - Returns the balance for the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Wallet balance retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "balanceDue": {
+                        "type": "number"
+                      },
+                      "creditLimit": {
+                        "type": "number"
+                      },
+                      "pendingCharges": {
+                        "type": "number"
+                      },
+                      "postedCharges": {
+                        "type": "number"
+                      },
+                      "spendingPower": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Balance information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Balance information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/withdrawal": {
+        "get": {
+          "summary": "Retrieve withdrawal detail for the customer",
+          "description": "This API returns the current withdrawal detail for the authenticated customer. The response includes:\n  - Controller address\n  - Withdrawal fee\n  - Balance information based on available token address\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "chainId",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Chain Id for getting the withdrawal detail",
+                "example": 84532
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Withdrawal details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "controllerAddress": {
+                        "type": "string",
+                        "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                      },
+                      "controllerContractAbi": {
+                        "type": "array",
+                        "example": []
+                      },
+                      "fees": {
+                        "type": "number",
+                        "description": "Withdrawal fee in cents",
+                        "example": 100
+                      },
+                      "bundlerUrl": {
+                        "type": "string",
+                        "example": "https://bundler.biconomy.io/api/v3/98765/xYzAbC9de.123a456b-78cd-90ef-12gh-345ijklm6789"
+                      },
+                      "paymasterUrl": {
+                        "type": "string",
+                        "example": "https://paymaster.biconomy.io/api/v2/98765/gH2klmNpQ.1a2b3c4d-5e6f-7890-gh12-ijk34lm56789"
+                      },
+                      "tokens": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                            },
+                            "balance": {
+                              "type": "number",
+                              "example": 50
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "ChainId is Invalid",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "chainId"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "chainId is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get withdrawal detail because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "chainId",
+                            "message": "Invalid chainId"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Withdrawal information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Balance information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "To generate withdrawal signature",
+          "description": "This API allows the authenticated customer for generating a withdrawal signature using chainId, token, amount and recipient address.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "chainId": {
+                      "type": "integer",
+                      "description": "The chain ID where the smart contract is deployed.",
+                      "example": 1
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "The address of the token to withdraw, as a hex string.",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "amount": {
+                      "type": "integer",
+                      "description": "The amount of the token to withdraw.",
+                      "example": 100
+                    },
+                    "recipientAddress": {
+                      "type": "string",
+                      "description": "The address to which the withdrawal should be sent, as a hex string.",
+                      "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Withdrawal signature retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "example": "Withdrawal signature retrieved successfully"
+                          },
+                          "withdrawalId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "996a751b-c47f-45c3-98f4-04afa9ce9a80"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "Success"
+                          },
+                          "retryCount": {
+                            "type": "integer",
+                            "example": 0
+                          },
+                          "signature": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string",
+                                "example": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c"
+                              },
+                              "salt": {
+                                "type": "string",
+                                "example": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                              }
+                            }
+                          },
+                          "expiresAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2025-01-31T04:52:45.000Z"
+                          },
+                          "senders": {
+                            "type": "string",
+                            "example": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931"
+                          },
+                          "parameters": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "example": "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F"
+                                },
+                                {
+                                  "type": "integer",
+                                  "example": 2410000
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer",
+                                    "example": [
+                                      57,
+                                      154,
+                                      15,
+                                      14,
+                                      48,
+                                      237,
+                                      226,
+                                      36,
+                                      148,
+                                      245,
+                                      242,
+                                      152,
+                                      252,
+                                      31,
+                                      203,
+                                      51,
+                                      88,
+                                      107,
+                                      251,
+                                      170,
+                                      118,
+                                      162,
+                                      229,
+                                      236,
+                                      51,
+                                      56,
+                                      254,
+                                      18,
+                                      26,
+                                      46,
+                                      81,
+                                      126
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "examples": {
+                    "signatureReady": {
+                      "summary": "Signature Ready",
+                      "value": {
+                        "message": "Withdrawal signature retrieved successfully",
+                        "withdrawalId": "996a751b-c47f-45c3-98f4-04afa9ce9a80",
+                        "status": "Success",
+                        "retryCount": 0,
+                        "signature": {
+                          "data": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c",
+                          "salt": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                        },
+                        "expiresAt": "2025-01-31T04:52:45.000Z",
+                        "senders": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931",
+                        "parameters": [
+                          "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F",
+                          "0x29684075a3C86ea11D9964BcAf0F956e801396bD",
+                          2410000,
+                          "0x67AC51b706b7f34cA7D966203aD904bE85762623",
+                          1738299165,
+                          [
+                            57,
+                            154,
+                            15,
+                            14,
+                            48,
+                            237,
+                            226,
+                            36,
+                            148,
+                            245,
+                            242,
+                            152,
+                            252,
+                            31,
+                            203,
+                            51,
+                            88,
+                            107,
+                            251,
+                            170,
+                            118,
+                            162,
+                            229,
+                            236,
+                            51,
+                            56,
+                            254,
+                            18,
+                            26,
+                            46,
+                            81,
+                            126
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get signature because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "chain Id",
+                            "message": "Invalid Chain Id"
+                          },
+                          {
+                            "field": "admin adress ",
+                            "message": "Invalid Admin Address"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "Invalid Amount"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "Invalid Withdrawal Amount, it must be a positive integer"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Signature Generation failed.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to generate signature. Please try again after 5 minutes. If any funds were deducted, don’t worry—they will be credited back within this time."
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Your signature request is still being processed. Please try again after 5 minute(s). If any funds were deducted, don’t worry—they will be credited back within this time."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/withdrawal/{id}": {
+        "put": {
+          "summary": "Update withdrawal status",
+          "description": "This API updates the status of the signature usage for a withdrawal request.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique identifier for the withdrawal request.",
+                "example": "a12345b6-78c9-0123-d456-789e012f34gh"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "New status of the withdrawal request.",
+                      "example": "success"
+                    },
+                    "txhash": {
+                      "type": "string",
+                      "description": "(Optional) Transaction hash if available.",
+                      "example": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Withdrawal status updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Withdrawal status updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get signature because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "Withdrawal Id",
+                            "message": "Invalid Withdrawal Id"
+                          },
+                          {
+                            "field": "Token ",
+                            "message": "Invalid token"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Withdrawal request not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Withdrawal with request ID 123 not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Internal Server Error: Unable to update withdrawal status."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/owner": {
+        "get": {
+          "summary": "Retrieve wallet address update status for the authenticated user",
+          "description": "This API retrieves the wallet status of the authenticated user.\n- Checks if the wallet address has been updated.\n- Identifies if the user is the wallet owner.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User wallet status retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User wallet status retrieved successfully"
+                      },
+                      "data": {
+                        "type": "object",
+                        "properties": {
+                          "isWalletUpdated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "isWalletOwner": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update wallet address for authenticated user",
+          "description": "Updates the wallet address. Once updated, further updates are restricted.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string",
+                      "description": "New wallet address for the user.",
+                      "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Wallet address updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Wallet address updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "address"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Address is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to update wallet address due to validation failures",
+                        "errors": [
+                          {
+                            "field": "address",
+                            "message": "Address is required"
+                          },
+                          {
+                            "field": "x-partner-code",
+                            "message": "Invalid partner code"
+                          },
+                          {
+                            "field": "x-app-code",
+                            "message": "Invalid app code"
+                          },
+                          {
+                            "field": "walletAddress",
+                            "message": "Wallet Address must be valid"
+                          }
+                        ]
+                      }
+                    },
+                    "walletAlreadyUpdated": {
+                      "summary": "Wallet Address Already Updated",
+                      "value": {
+                        "message": "Wallet Address already updated"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Internal Server Error: Unable to update wallet address."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "SignInEmailRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's email address",
+              "example": "user@example.com"
+            },
+            "password": {
+              "type": "string",
+              "description": "The user's password",
+              "example": "password123"
+            }
+          },
+          "required": [
+            "email",
+            "password"
+          ]
+        },
+        "SignInResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Successfully authenticated."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            },
+            "token2fa": {
+              "type": "string",
+              "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+              "example": "U2FsdGVkX1...",
+              "nullable": true
+            }
+          }
+        },
+        "SignInSocialResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Successfully authenticated."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            },
+            "token2fa": {
+              "type": "string",
+              "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+              "example": "U2FsdGVkX1...",
+              "nullable": true
+            }
+          }
+        },
+        "SignInEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid credentials"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignInSocialRequest": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "The social provider used for signing in (e.g., google, facebook)",
+              "example": "google"
+            },
+            "token": {
+              "type": "string",
+              "description": "The OAuth token from the social provider",
+              "example": "eyJhbGciOiJIUzI1..."
+            }
+          },
+          "required": [
+            "provider",
+            "token"
+          ]
+        },
+        "SignInSocialErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid social token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignOutErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while signing out"
+            }
+          }
+        },
+        "SignInMobileRequest": {
+          "type": "object",
+          "properties": {
+            "authToken": {
+              "type": "string",
+              "description": "The permanent mobile verification code issued after successful mobile verification via the **verify-otp** API.",
+              "example": "eyJhbGciOiJIUzI1..."
+            }
+          },
+          "required": [
+            "authToken"
+          ]
+        },
+        "SignInMobileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid verification code"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignUpEmailRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's email address",
+              "example": "user@example.com"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The user's first name",
+              "example": "John"
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The user's last name",
+              "example": "Doe"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        },
+        "SignUpEmailResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "User registered successfully. Please verify your email."
+            }
+          }
+        },
+        "SignUpEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error",
+              "example": "A descriptive error message"
+            },
+            "error": {
+              "type": "string",
+              "description": "Optional detailed error information (only for server errors)",
+              "example": "Detailed error information"
+            }
+          }
+        },
+        "VerifyEmailResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message indicating the email has been verified.",
+              "example": "Email verified successfully. Please create your password."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          }
+        },
+        "VerifyEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Error message if the token is invalid or expired",
+              "example": "Invalid or expired token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information",
+              "example": "Verification failed"
+            }
+          }
+        },
+        "RefreshTokenRequest": {
+          "type": "object",
+          "properties": {
+            "refreshToken": {
+              "type": "string",
+              "description": "The refresh token provided during sign-in *",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          },
+          "required": [
+            "refreshToken"
+          ]
+        },
+        "RefreshTokenResponse": {
+          "type": "object",
+          "properties": {
+            "accessToken": {
+              "type": "string",
+              "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "(Optional) A new refresh token, if a new one is issued",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          }
+        },
+        "RefreshTokenErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid refresh token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information",
+              "example": "Refresh token expired or invalid"
+            }
+          }
+        },
+        "CaptchaInitResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha challenge initialized successfully."
+            },
+            "status": {
+              "type": "string",
+              "example": "success"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "lot_number": {
+                  "type": "string",
+                  "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                },
+                "captcha_type": {
+                  "type": "string",
+                  "example": "slide"
+                },
+                "captcha_output": {
+                  "type": "string",
+                  "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+                },
+                "pass_token": {
+                  "type": "string",
+                  "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+                },
+                "captcha_id": {
+                  "type": "string",
+                  "example": "fb362ff464a632747b0dd0ea90bab013"
+                }
+              }
+            }
+          }
+        },
+        "CaptchaValidationRequest": {
+          "type": "object",
+          "properties": {
+            "mobile": {
+              "type": "string",
+              "example": "9456262167"
+            },
+            "captcha_id": {
+              "type": "string",
+              "example": "d81db9ghjk82bc8abb8b93a6b24b"
+            },
+            "lot_number": {
+              "type": "string",
+              "example": "362ff4642747b0dd0ea90bab013ss"
+            },
+            "captcha_output": {
+              "type": "string",
+              "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+            },
+            "pass_token": {
+              "type": "string",
+              "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+            },
+            "gen_time": {
+              "type": "string",
+              "example": "1747751473"
+            }
+          },
+          "required": [
+            "mobile",
+            "captcha_id",
+            "lot_number",
+            "captcha_output",
+            "pass_token",
+            "gen_time"
+          ]
+        },
+        "CaptchaValidationResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha validated successfully."
+            },
+            "accessToken": {
+              "type": "string",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+            }
+          }
+        },
+        "CaptchaValidationErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha validation failed."
+            },
+            "error": {
+              "type": "string",
+              "example": "pass_token expire"
+            }
+          }
+        },
+        "Generate2FASecretResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message",
+              "example": "2FA secret generated successfully."
+            },
+            "qrCodeData": {
+              "type": "string",
+              "description": "QR code image data for scanning",
+              "example": "data:image/png;base64,iVBORw0..."
+            },
+            "secret": {
+              "type": "string",
+              "description": "The secret, in case user wants to manually enter it",
+              "example": "JBSWY3DPEHPK3PXP"
+            }
+          }
+        },
+        "Enable2FARequest": {
+          "type": "object",
+          "properties": {
+            "token": {
+              "type": "string",
+              "description": "token generated by the user's authenticator app",
+              "example": 123456
+            }
+          },
+          "required": [
+            "token"
+          ]
+        },
+        "Enable2FAResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Two-factor authentication enabled successfully."
+            }
+          }
+        },
+        "Enable2FAErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while enabling two-factor authentication."
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message if OTP verification fails",
+              "example": "Invalid OTP. Please try again."
+            }
+          }
+        },
+        "User": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The person's first name",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The person's last name",
+              "maxLength": 50
+            },
+            "birthDate": {
+              "type": "string",
+              "format": "date",
+              "description": "The person's birth date"
+            },
+            "nationalId": {
+              "type": "string",
+              "description": "National ID (9-digit SSN for US users)"
+            },
+            "countryOfIssue": {
+              "type": "string",
+              "description": "2-letter country code where the ID was issued",
+              "maxLength": 2
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The person's email address"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The person's address"
+                }
+              ]
+            }
+          },
+          "required": [
+            "firstName",
+            "lastName",
+            "birthDate",
+            "nationalId",
+            "countryOfIssue",
+            "email",
+            "address"
+          ]
+        },
+        "Document": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the document",
+              "example": "passport_image.png"
+            },
+            "type": {
+              "type": "string",
+              "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+              "example": "CERT_INC"
+            },
+            "side": {
+              "type": "string",
+              "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+              "example": "front, back"
+            },
+            "country": {
+              "type": "string",
+              "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+              "example": "USA",
+              "maxLength": 3
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "InitialUser": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The initial user of the company",
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "description": "This user's role at their company"
+                },
+                "walletAddress": {
+                  "type": "string",
+                  "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                },
+                "ipAddress": {
+                  "type": "string",
+                  "description": "The user's IP address"
+                },
+                "iovationBlackbox": {
+                  "type": "string",
+                  "description": "A blackbox string generated by the client side Iovation library"
+                }
+              },
+              "required": [
+                "iovationBlackbox",
+                "ipAddress",
+                "isTermsOfServiceAccepted"
+              ]
+            }
+          ]
+        },
+        "Address": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "line1": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "line2": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "city": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "region": {
+              "type": "string",
+              "maxLength": 60
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 15
+            },
+            "countryCode": {
+              "type": "string",
+              "maxLength": 2
+            },
+            "country": {
+              "type": "string",
+              "maxLength": 50
+            }
+          },
+          "required": [
+            "line1",
+            "city",
+            "region",
+            "postalCode",
+            "countryCode",
+            "country"
+          ]
+        },
+        "Entity": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "name": {
+              "type": "string",
+              "description": "The legal entity's name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The legal entity's type - LLC, S Corp, etc."
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the legal entity, and its activities"
+            },
+            "taxId": {
+              "type": "string",
+              "description": "The legal entity's national tax id"
+            },
+            "registrationNumber": {
+              "type": "string",
+              "description": "The legal entity's registration number"
+            },
+            "website": {
+              "type": "string",
+              "description": "The legal entity's website"
+            },
+            "expectedSpend": {
+              "type": "string",
+              "description": "How much the legal entity expects to spend each month"
+            },
+            "industry": {
+              "type": "string",
+              "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+            }
+          },
+          "required": [
+            "name",
+            "taxId",
+            "registrationNumber",
+            "website"
+          ]
+        },
+        "UserAddress": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "line2": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "region": {
+                  "type": "string",
+                  "maxLength": 60
+                },
+                "postalCode": {
+                  "type": "string",
+                  "maxLength": 15
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "region",
+                "postalCode",
+                "countryCode",
+                "country"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The person's address"
+            }
+          ]
+        },
+        "BusinessAddress": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "line2": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "region": {
+                  "type": "string",
+                  "maxLength": 60
+                },
+                "postalCode": {
+                  "type": "string",
+                  "maxLength": 15
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "region",
+                "postalCode",
+                "countryCode",
+                "country"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The company's physical address"
+            }
+          ]
+        },
+        "ProfileUser": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "This is the profile of the user"
+            }
+          ]
+        },
+        "ProfileCompany": {
+          "allOf": [
+            {
+              "type": "object",
+              "description": "This is the profile of the company",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            }
+          ]
+        },
+        "Profile": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "firstName": {
+                          "type": "string",
+                          "description": "The person's first name",
+                          "maxLength": 50
+                        },
+                        "lastName": {
+                          "type": "string",
+                          "description": "The person's last name",
+                          "maxLength": 50
+                        },
+                        "birthDate": {
+                          "type": "string",
+                          "format": "date",
+                          "description": "The person's birth date"
+                        },
+                        "nationalId": {
+                          "type": "string",
+                          "description": "National ID (9-digit SSN for US users)"
+                        },
+                        "countryOfIssue": {
+                          "type": "string",
+                          "description": "2-letter country code where the ID was issued",
+                          "maxLength": 2
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "The person's email address"
+                        },
+                        "address": {
+                          "allOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "line1": {
+                                  "type": "string",
+                                  "maxLength": 100
+                                },
+                                "line2": {
+                                  "type": "string",
+                                  "maxLength": 100
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "maxLength": 50
+                                },
+                                "region": {
+                                  "type": "string",
+                                  "maxLength": 60
+                                },
+                                "postalCode": {
+                                  "type": "string",
+                                  "maxLength": 15
+                                },
+                                "countryCode": {
+                                  "type": "string",
+                                  "maxLength": 2
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "maxLength": 50
+                                }
+                              },
+                              "required": [
+                                "line1",
+                                "city",
+                                "region",
+                                "postalCode",
+                                "countryCode",
+                                "country"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "description": "The person's address"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "firstName",
+                        "lastName",
+                        "birthDate",
+                        "nationalId",
+                        "countryOfIssue",
+                        "email",
+                        "address"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "This is the profile of the user"
+                    }
+                  ]
+                }
+              ]
+            },
+            "company": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "description": "This is the profile of the company",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "user",
+            "company"
+          ]
+        },
+        "GetProfileResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Profile retrieved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique ID of the KYB draft.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the company.",
+              "example": "Acme Corp"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The company's physical address"
+                }
+              ]
+            },
+            "company": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            },
+            "documents": {
+              "type": "array",
+              "description": "List of KYB documents.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the document",
+                    "example": "passport_image.png"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                    "example": "CERT_INC"
+                  },
+                  "side": {
+                    "type": "string",
+                    "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                    "example": "front, back"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                    "example": "USA",
+                    "maxLength": 3
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            },
+            "representatives": {
+              "type": "array",
+              "description": "List of company representatives.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            },
+            "status": {
+              "type": "string",
+              "description": "The current status of the KYB process.",
+              "example": "Pending"
+            },
+            "ultimateBeneficialOwners": {
+              "type": "array",
+              "description": "List of the company's ultimate beneficial owners.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            }
+          }
+        },
+        "GetProfileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message for the failed profile retrieval.",
+              "example": "Error occurred while retrieving the profile."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information to assist in troubleshooting.",
+              "example": "Profile not found."
+            }
+          }
+        },
+        "UpdateProfileRequest": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "This is the profile of the user"
+                }
+              ]
+            },
+            "company": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "This is the profile of the company",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The legal entity's name"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The legal entity's type - LLC, S Corp, etc."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the legal entity, and its activities"
+                    },
+                    "taxId": {
+                      "type": "string",
+                      "description": "The legal entity's national tax id"
+                    },
+                    "registrationNumber": {
+                      "type": "string",
+                      "description": "The legal entity's registration number"
+                    },
+                    "website": {
+                      "type": "string",
+                      "description": "The legal entity's website"
+                    },
+                    "expectedSpend": {
+                      "type": "string",
+                      "description": "How much the legal entity expects to spend each month"
+                    },
+                    "industry": {
+                      "type": "string",
+                      "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "taxId",
+                    "registrationNumber",
+                    "website"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "UpdateProfileResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Profile updated successfully."
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "user": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "This is the profile of the user"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "company": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "description": "This is the profile of the company",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The legal entity's name"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "The legal entity's type - LLC, S Corp, etc."
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "A brief description of the legal entity, and its activities"
+                            },
+                            "taxId": {
+                              "type": "string",
+                              "description": "The legal entity's national tax id"
+                            },
+                            "registrationNumber": {
+                              "type": "string",
+                              "description": "The legal entity's registration number"
+                            },
+                            "website": {
+                              "type": "string",
+                              "description": "The legal entity's website"
+                            },
+                            "expectedSpend": {
+                              "type": "string",
+                              "description": "How much the legal entity expects to spend each month"
+                            },
+                            "industry": {
+                              "type": "string",
+                              "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "taxId",
+                            "registrationNumber",
+                            "website"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "user",
+                "company"
+              ]
+            }
+          }
+        },
+        "ProfileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Error occurred while processing the profile request."
+            },
+            "error": {
+              "type": "string",
+              "example": "Invalid input or data not found."
+            }
+          }
+        },
+        "KYBFormRequest": {
+          "type": "object",
+          "properties": {
+            "initialUser": {
+              "type": "object",
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The initial user of the company",
+                  "properties": {
+                    "role": {
+                      "type": "string",
+                      "description": "This user's role at their company"
+                    },
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                    },
+                    "ipAddress": {
+                      "type": "string",
+                      "description": "The user's IP address"
+                    },
+                    "iovationBlackbox": {
+                      "type": "string",
+                      "description": "A blackbox string generated by the client side Iovation library"
+                    }
+                  },
+                  "required": [
+                    "iovationBlackbox",
+                    "ipAddress",
+                    "isTermsOfServiceAccepted"
+                  ]
+                }
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the company looking to create an account"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The company's physical address"
+                }
+              ]
+            },
+            "chainId": {
+              "type": "string",
+              "description": "the chain id of the company's external collateral contract"
+            },
+            "contractAddress": {
+              "type": "string",
+              "description": "the address of the company's external collateral contract;"
+            },
+            "entity": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            },
+            "representatives": {
+              "type": "array",
+              "description": "The company's representatives",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            },
+            "ultimateBeneficialOwners": {
+              "type": "array",
+              "description": "The company's ultimate beneficial owners",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            }
+          },
+          "required": [
+            "initialUser",
+            "name",
+            "address",
+            "entity",
+            "representatives",
+            "ultimateBeneficialOwners"
+          ]
+        },
+        "KYBFormResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Indicates the form is in draft mode.",
+              "example": "Pending",
+              "enum": [
+                "PENDING"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "description": "Message providing more information about the draft status.",
+              "example": "KYB information saved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique ID for tracking the draft submission.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO timestamp of the last update.",
+              "example": "2024-10-14T12:34:56Z"
+            }
+          }
+        },
+        "ErrorResponse": {
+          "type": "object",
+          "properties": {
+            "field": {
+              "type": "string",
+              "description": "The form field with the issue.",
+              "example": "businessName"
+            },
+            "message": {
+              "type": "string",
+              "description": "Description of the validation error.",
+              "example": "The business name is required."
+            }
+          }
+        },
+        "FormErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "General message about the validation error.",
+              "example": "Validation Failed"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "The form field with the issue.",
+                    "example": "businessName"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "Description of the validation error.",
+                    "example": "The business name is required."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYBResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "KYB information retrieved successfully."
+            },
+            "kybData": {
+              "type": "object",
+              "description": "The KYB information retrieved for the company.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The unique ID of the KYB draft.",
+                  "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the company.",
+                  "example": "Acme Corp"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The company's physical address"
+                    }
+                  ]
+                },
+                "chainId": {
+                  "type": "string",
+                  "description": "the chain id of the company's external collateral contract"
+                },
+                "documents": {
+                  "type": "array",
+                  "description": "List of KYB documents.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the document",
+                        "example": "passport_image.png"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                        "example": "CERT_INC"
+                      },
+                      "side": {
+                        "type": "string",
+                        "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                        "example": "front, back"
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                        "example": "USA",
+                        "maxLength": 3
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "entity": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The legal entity's name"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The legal entity's type - LLC, S Corp, etc."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the legal entity, and its activities"
+                    },
+                    "taxId": {
+                      "type": "string",
+                      "description": "The legal entity's national tax id"
+                    },
+                    "registrationNumber": {
+                      "type": "string",
+                      "description": "The legal entity's registration number"
+                    },
+                    "website": {
+                      "type": "string",
+                      "description": "The legal entity's website"
+                    },
+                    "expectedSpend": {
+                      "type": "string",
+                      "description": "How much the legal entity expects to spend each month"
+                    },
+                    "industry": {
+                      "type": "string",
+                      "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "taxId",
+                    "registrationNumber",
+                    "website"
+                  ]
+                },
+                "representatives": {
+                  "type": "array",
+                  "description": "List of company representatives.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The person's first name",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The person's last name",
+                        "maxLength": 50
+                      },
+                      "birthDate": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "The person's birth date"
+                      },
+                      "nationalId": {
+                        "type": "string",
+                        "description": "National ID (9-digit SSN for US users)"
+                      },
+                      "countryOfIssue": {
+                        "type": "string",
+                        "description": "2-letter country code where the ID was issued",
+                        "maxLength": 2
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The person's email address"
+                      },
+                      "address": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "line2": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "city": {
+                                "type": "string",
+                                "maxLength": 50
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 60
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "maxLength": 15
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "maxLength": 2
+                              },
+                              "country": {
+                                "type": "string",
+                                "maxLength": 50
+                              }
+                            },
+                            "required": [
+                              "line1",
+                              "city",
+                              "region",
+                              "postalCode",
+                              "countryCode",
+                              "country"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "description": "The person's address"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName",
+                      "birthDate",
+                      "nationalId",
+                      "countryOfIssue",
+                      "email",
+                      "address"
+                    ]
+                  }
+                },
+                "ultimateBeneficialOwners": {
+                  "type": "array",
+                  "description": "List of the company's ultimate beneficial owners.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The person's first name",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The person's last name",
+                        "maxLength": 50
+                      },
+                      "birthDate": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "The person's birth date"
+                      },
+                      "nationalId": {
+                        "type": "string",
+                        "description": "National ID (9-digit SSN for US users)"
+                      },
+                      "countryOfIssue": {
+                        "type": "string",
+                        "description": "2-letter country code where the ID was issued",
+                        "maxLength": 2
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The person's email address"
+                      },
+                      "address": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "line2": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "city": {
+                                "type": "string",
+                                "maxLength": 50
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 60
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "maxLength": 15
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "maxLength": 2
+                              },
+                              "country": {
+                                "type": "string",
+                                "maxLength": 50
+                              }
+                            },
+                            "required": [
+                              "line1",
+                              "city",
+                              "region",
+                              "postalCode",
+                              "countryCode",
+                              "country"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "description": "The person's address"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName",
+                      "birthDate",
+                      "nationalId",
+                      "countryOfIssue",
+                      "email",
+                      "address"
+                    ]
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "description": "The current status of the KYB process.",
+                  "example": "Pending"
+                },
+                "referralCode": {
+                  "type": "string",
+                  "example": "ABCD1234"
+                },
+                "referralCount": {
+                  "type": "number",
+                  "example": 10
+                }
+              }
+            }
+          }
+        },
+        "GetKYBErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message.",
+              "example": "Error occurred while retrieving KYB information."
+            },
+            "error": {
+              "type": "string",
+              "description": "A detailed error message for troubleshooting.",
+              "example": "KYB record not found."
+            }
+          }
+        },
+        "KYBStatusResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "example": "pending",
+              "enum": [
+                "notStarted",
+                "pending",
+                "pendingEmailVerification",
+                "emailVerified",
+                "saved",
+                "needsVerification",
+                "verificationPending",
+                "underReview",
+                "manualReview",
+                "needsInformation",
+                "verified",
+                "rejected",
+                "cancelled",
+                "denied",
+                "locked"
+              ]
+            }
+          }
+        },
+        "KYBStatusErrorResponse": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "example": "MISSING_INFORMATION"
+            },
+            "message": {
+              "type": "string",
+              "example": "Additional business details required."
+            }
+          }
+        },
+        "KYBSubmitResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A message providing more information about the submission.",
+              "example": "KYB form submitted successfully."
+            }
+          }
+        },
+        "IndividualUserAddress": {
+          "type": "object",
+          "properties": {
+            "line1": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "city": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "countryCode": {
+              "type": "string",
+              "maxLength": 2
+            },
+            "country": {
+              "type": "string",
+              "maxLength": 50
+            }
+          },
+          "required": [
+            "line1",
+            "city",
+            "countryCode",
+            "country"
+          ]
+        },
+        "IndividualUserRequest": {
+          "type": "object",
+          "properties": {
+            "firstName": {
+              "type": "string",
+              "description": "The customer's first name",
+              "example": "John",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The customer's last name",
+              "example": "Doe",
+              "maxLength": 50
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The customer's email address",
+              "example": "john.doe@example.com"
+            },
+            "birthDate": {
+              "type": "string",
+              "format": "date",
+              "description": "The person's birth date"
+            },
+            "address": {
+              "type": "object",
+              "properties": {
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "countryCode",
+                "country"
+              ]
+            },
+            "phoneCountryCode": {
+              "type": "string",
+              "description": "Customer country code",
+              "example": 91,
+              "maxLength": 3
+            },
+            "phoneNumber": {
+              "type": "string",
+              "description": "phoneNumber",
+              "example": 9999999999,
+              "maxLength": 15
+            },
+            "occupation": {
+              "type": "string",
+              "description": "occupation code fetched from master api",
+              "example": "11-3011",
+              "maxLength": 50
+            },
+            "annualSalary": {
+              "type": "number",
+              "description": "annualSalary",
+              "example": 4000000
+            },
+            "accountPurpose": {
+              "type": "string",
+              "description": "accountPurpose",
+              "example": "Investment",
+              "maxLength": 15
+            },
+            "expectedMonthlySpend": {
+              "type": "number",
+              "description": "expectedMonthlySpend",
+              "example": 10000
+            },
+            "walletAddress": {
+              "type": "string",
+              "description": "The person's wallet address; required if using the hosted completion flow and a non-custodial solution, but not required otherwise",
+              "example": "0x1234...abcd"
+            },
+            "isTermOfServiceAccepted": {
+              "type": "boolean",
+              "description": "is customer accepted all terms of service",
+              "example": true
+            },
+            "isWalletOwner": {
+              "type": "boolean",
+              "description": "is customer owner of wallet address",
+              "example": true
+            }
+          },
+          "required": [
+            "firstName",
+            "lastName",
+            "birthDate",
+            "walletAddress",
+            "address",
+            "ipAddress",
+            "isTermOfServiceAccepted"
+          ]
+        },
+        "KYCFormResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Indicates the form is in draft mode.",
+              "example": "Pending",
+              "enum": [
+                "PENDING"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "description": "Message providing more information about the draft status.",
+              "example": "KYC application initiated successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique ID for tracking the draft submission.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO timestamp of the last update.",
+              "example": "2024-10-14T12:34:56Z"
+            },
+            "nextSteps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "verificationLink": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "example": "https://app-kyc.xyz/kyc"
+                      },
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                          },
+                          "redirect": {
+                            "type": "string",
+                            "format": "url",
+                            "example": "https://app-qa.pay.com/kycConfirmation"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "KYCErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Error message indicating the reason for failure",
+              "example": "Unable to initiate KYC because of the validation failures"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "The field that caused the validation error",
+                    "example": "walletAddress"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "The validation error message",
+                    "example": "walletAddress must be a valid address"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYCResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "KYC information retrieved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique ID of the KYC draft.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The first name of the individual user.",
+              "example": "John",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The last name of the individual user.",
+              "example": "Doe",
+              "maxLength": 50
+            },
+            "createdOn": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The date and time when the user registers in the system.",
+              "example": "2024-10-14T12:34:56Z"
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The email address of the individual user.",
+              "example": "johndoe@johndoe.com"
+            },
+            "address": {
+              "type": "object",
+              "properties": {
+                "line1": {
+                  "type": "string",
+                  "description": "The first line of the address.",
+                  "example": "123, ABC Street",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "description": "The city of the address.",
+                  "example": "XYZ",
+                  "maxLength": 50
+                },
+                "countryCode": {
+                  "type": "string",
+                  "description": "The country code of the address.",
+                  "example": "IN",
+                  "maxLength": 2,
+                  "minLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "description": "The country of the address.",
+                  "example": "India",
+                  "maxLength": 50
+                }
+              }
+            },
+            "phoneCountryCode": {
+              "type": "string",
+              "description": "The country code of the phone number.",
+              "example": "91",
+              "maxLength": 3
+            },
+            "phoneNumber": {
+              "type": "string",
+              "description": "The phone number of the individual user.",
+              "example": "1234567890",
+              "maxLength": 15,
+              "minLength": 1
+            },
+            "badge": {
+              "type": "object",
+              "description": "Badge earned by the user based on their activities in the system.",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Short code for the badge.",
+                  "example": "SupF"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Full name of the badge.",
+                  "example": "SuperFan"
+                }
+              }
+            },
+            "referralCode": {
+              "type": "string",
+              "example": "ABCD1234"
+            },
+            "referralDiscount": {
+              "type": "number",
+              "description": "Discount value for the referral.",
+              "example": 0.1
+            },
+            "referralDiscountType": {
+              "type": "string",
+              "description": "Type of discount applied",
+              "example": "percentage",
+              "enum": [
+                "percentage",
+                "flat"
+              ]
+            },
+            "referralCount": {
+              "type": "number",
+              "example": 10
+            },
+            "referrerCode": {
+              "type": "string",
+              "example": "absdkfjhdsd"
+            },
+            "referrerDiscount": {
+              "type": "number",
+              "description": "Discount value for the referral.",
+              "example": 100
+            },
+            "referrerDiscountType": {
+              "type": "string",
+              "description": "Type of discount applied",
+              "example": "flat",
+              "enum": [
+                "percentage",
+                "flat"
+              ]
+            },
+            "walletAddress": {
+              "type": "string",
+              "description": "The wallet address of the individual user.",
+              "example": "0x1234567890abcdef1234567890abcdef12345678"
+            },
+            "nextSteps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "verificationLink": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "example": "https://app-kyc.xyz/kyc"
+                      },
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                          },
+                          "redirect": {
+                            "type": "string",
+                            "format": "url",
+                            "example": "https://app-qa.pay.com/kycConfirmation"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYCErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message.",
+              "example": "Error occurred while retrieving KYC information."
+            },
+            "error": {
+              "type": "string",
+              "description": "A detailed error message for troubleshooting.",
+              "example": "KYC record not found."
+            }
+          }
+        },
+        "MasterType": {
+          "type": "string",
+          "enum": [
+            "Country",
+            "DocumentType",
+            "DepositToken",
+            "CardStatus",
+            "UserRole",
+            "CardProduct",
+            "Consent"
+          ]
+        },
+        "MasterData": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "example": 1
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Country",
+                "DocumentType",
+                "DepositToken",
+                "CardStatus",
+                "UserRole",
+                "CardProduct",
+                "Consent"
+              ]
+            },
+            "key": {
+              "type": "string",
+              "example": "IN"
+            },
+            "value": {
+              "type": "string",
+              "example": "India"
+            },
+            "description": {
+              "type": "string",
+              "example": "Country in South Asia"
+            },
+            "isActive": {
+              "type": "boolean",
+              "example": true
+            }
+          }
+        },
+        "MasterDataResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "Master Data updated successfully"
+            },
+            "data": {
+              "type": "array",
+              "description": "List of naster data.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "example": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Country",
+                      "DocumentType",
+                      "DepositToken",
+                      "CardStatus",
+                      "UserRole",
+                      "CardProduct",
+                      "Consent"
+                    ]
+                  },
+                  "key": {
+                    "type": "string",
+                    "example": "IN"
+                  },
+                  "value": {
+                    "type": "string",
+                    "example": "India"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "Country in South Asia"
+                  },
+                  "isActive": {
+                    "type": "boolean",
+                    "example": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ConsumerOccupation": {
+          "type": "object",
+          "description": "Represents a consumer occupation entry.",
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Unique code identifier for the occupation.",
+              "example": "11-3011"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the occupation.",
+              "example": "Administrative Services Managers"
+            },
+            "isActive": {
+              "type": "boolean",
+              "description": "Indicates if the occupation record is currently active.",
+              "example": true
+            }
+          },
+          "required": [
+            "code",
+            "name",
+            "isActive"
+          ]
+        },
+        "NotificationUpdateRequest": {
+          "type": "object",
+          "properties": {
+            "read": {
+              "type": "boolean",
+              "description": "Whether the notification is read or not",
+              "example": true
+            }
+          }
+        },
+        "NotificationResponse": {
+          "type": "object",
+          "properties": {
+            "notifications": {
+              "type": "array",
+              "description": "List of user notifications",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "example": 1
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Your profile has been updated."
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2024-10-11T12:00:00Z"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "NotificationErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while fetching notifications."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Unable to retrieve notifications"
+            }
+          }
+        },
+        "CreatePasswordRequest": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "password"
+          ]
+        },
+        "CreatePasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Failed to create a password. Please ensure your token is valid and try again."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+              "example": "weak password"
+            }
+          }
+        },
+        "CreatePasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message",
+              "example": "Password created successfully. You can now sign in."
+            }
+          }
+        },
+        "ChangePasswordRequest": {
+          "type": "object",
+          "properties": {
+            "oldPassword": {
+              "type": "string",
+              "format": "password",
+              "description": "The user's current password",
+              "example": "oldpassword123"
+            },
+            "newPassword": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "oldPassword",
+            "newPassword"
+          ]
+        },
+        "ChangePasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password changed successfully."
+            }
+          }
+        },
+        "ChangePasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while changing password."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Old password is incorrect"
+            }
+          }
+        },
+        "ForgotPasswordRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's registered email address",
+              "example": "user@example.com"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        },
+        "ForgotPasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password reset link sent to your email."
+            }
+          }
+        },
+        "ForgotPasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while sending password reset link."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "User not found"
+            }
+          }
+        },
+        "ResetPasswordRequest": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "password"
+          ]
+        },
+        "ResetPasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password reset successfully."
+            }
+          }
+        },
+        "ResetPasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Failed to create a password. Please ensure your token is valid and try again."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+              "example": "weak password"
+            }
+          }
+        },
+        "DocumentType": {
+          "type": "string",
+          "enum": [
+            "CERT_INC",
+            "COMP_REG",
+            "SH_REG",
+            "M_REG",
+            "PASSPORT",
+            "DL",
+            "NATIONALID"
+          ]
+        },
+        "DocumentSide": {
+          "type": "string",
+          "enum": [
+            "FRONT",
+            "BACK"
+          ]
+        },
+        "UploadRequest": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the document.",
+              "example": "passport.pdf"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "CERT_INC",
+                "COMP_REG",
+                "SH_REG",
+                "M_REG",
+                "PASSPORT",
+                "DL",
+                "NATIONALID"
+              ]
+            },
+            "side": {
+              "type": "string",
+              "enum": [
+                "FRONT",
+                "BACK"
+              ]
+            },
+            "country": {
+              "type": "string",
+              "description": "The country associated with the document.",
+              "example": "USA",
+              "maxLength": 3,
+              "minLength": 3
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "UploadResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A message about the success of the upload.",
+              "example": "Document uploaded successfully"
+            },
+            "documentId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The id of the uploaded file.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        },
+        "UploadError": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "The HTTP status code.",
+              "example": 400
+            },
+            "error": {
+              "type": "string",
+              "description": "A short description of the error.",
+              "example": "Invalid file type"
+            },
+            "message": {
+              "type": "string",
+              "description": "A detailed message about the error.",
+              "example": "Only PDF, JPEG, JPG, and PNG file types are allowed."
+            }
+          }
+        }
+      },
+      "responses": {
+        "UnauthorizedError": {
+          "description": "Access is denied due to invalid or missing token.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Unauthorized access. Token is missing or invalid."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Invalid or expired token"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "InternalServerError": {
+          "description": "An unexpected error occurred on the server.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Something went wrong on the server. Please try again later."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Internal Server Error"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ForbiddenError": {
+          "description": "Token expired or not authorized.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "You are not authorized to access this resource. Please log in again."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "securitySchemes": {
+        "bearerAuth": {
+          "type": "http",
+          "scheme": "bearer",
+          "bearerFormat": "JWT"
+        },
+        "appKeyAuth": {
+          "type": "apiKey",
+          "name": "x-app-code",
+          "in": "header"
+        }
+      }
+    },
+    "security": [
+      {
+        "bearerAuth": []
+      },
+      {
+        "appKeyAuth": []
+      }
+    ],
+    "tags": [
+      {
+        "name": "Authentication",
+        "description": "Operations related to authentication"
+      },
+      {
+        "name": "Captcha",
+        "description": "Initializing and validating Geetest CAPTCHA challenges, used to verify human interaction on the frontend."
+      },
+      {
+        "name": "Password Management",
+        "description": "Operations related to user account password"
+      },
+      {
+        "name": "Two-Factor Authentication",
+        "description": "Operations related to two-factor authentication"
+      },
+      {
+        "name": "KYB",
+        "description": "Operations related to Corporate Customer Application"
+      },
+      {
+        "name": "KYC",
+        "description": "Operations related to Individual Customer Application"
+      },
+      {
+        "name": "Verification",
+        "description": "Operations related to KYB/KYC status"
+      },
+      {
+        "name": "Card Management",
+        "description": "Operations related to cards"
+      },
+      {
+        "name": "Master Management",
+        "description": "Operations related to master Data"
+      },
+      {
+        "name": "User Management",
+        "description": "Operations related to user Data"
+      },
+      {
+        "name": "Wallet",
+        "description": "Operations related to deposits"
+      },
+      {
+        "name": "Transactions",
+        "description": "Operations related to transactions"
+      }
+    ]
+  }

--- a/api-reference/consumer.json
+++ b/api-reference/consumer.json
@@ -1,0 +1,16116 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OrbitXPay API",
+    "version": "1.0.0",
+    "description": "\nThis API is designed for managing the functionalities of **OrbitXPay**.\n\n## Authentication\n\nThe API uses **Bearer Token** authentication. All requests to secured endpoints must include the following header:\n\n```\nAuthorization: Bearer <your-token>\n```\n\n### How to Obtain the Token\n1. Authenticate by sending a request to the **`/auth/signin-email`** OR **`/auth/signin-social`** endpoint.\n2. Upon successful authentication, you will receive a Bearer token.\n\n### Error Responses\n- **`401 Unauthorized`**: Returned if the token is missing, invalid, or expired.\n- **`403 Forbidden`**: Returned if the token does not have sufficient permissions to access the requested resource.\n\n---\n\nFor further details, refer to individual endpoints.\n"
+  },
+  "servers": [
+    {
+      "url": "https://api-qa.orbitxpay.com/api/v1",
+      "description": "API server V1"
+    }
+  ],
+  "paths": {
+    "/auth/signup-email": {
+      "post": {
+        "summary": "Register a new user",
+        "description": "This API is used to register a new user in the system. Upon successful registration:\n- The request requires the **x-app-code** header for authentication and the Partner Code to associate the customer to a particular partner.\n- An email containing a verification link is sent to the provided email address.\n- The user must click the verification link to confirm their email address.\n- Until the email is verified, the account will remain inactive.\n- To verify the email, the user needs to call the **Verify Email API** with the verification token sent in the email.\n\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The user's email address",
+                    "example": "user@example.com"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The user's first name",
+                    "example": "John"
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The user's last name",
+                    "example": "Doe"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "User registered successfully, email verification link sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Confirmation message for the user",
+                      "example": "User registered successfully. Please verify your email."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error",
+                      "example": "A descriptive error message"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Optional detailed error information (only for server errors)",
+                      "example": "Detailed error information"
+                    }
+                  }
+                },
+                "examples": {
+                  "MissingFields": {
+                    "summary": "Required fields are missing",
+                    "value": {
+                      "message": "One or more required fields are missing",
+                      "error": "Missing Fields"
+                    }
+                  },
+                  "EmailAlreadyExists": {
+                    "summary": "Email already registered",
+                    "value": {
+                      "message": "Email is already registered",
+                      "error": "Email Already Exists"
+                    }
+                  },
+                  "InvalidEmail": {
+                    "summary": "Email is invalid",
+                    "value": {
+                      "message": "Email is invalid",
+                      "error": "Invalid Email"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/verify-email": {
+      "put": {
+        "summary": "Verify user email address",
+        "description": "This API is used to verify the email address of a user after they click the verification link in their email. \nThe user must provide the verification token received in their email.\n\nUpon successful verification:\n- The user's email is marked as verified in the system.\n- The account will be activated.\n- A **temporary token** will be generated and returned.\n- This temporary token is required to create the user’s password in the next step.\n       \nIf the token is invalid or expired:\n- The user will receive an error response indicating the failure.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "description": "The verification token sent via email",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email verified successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Success message indicating the email has been verified.",
+                      "example": "Email verified successfully. Please create your password."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "Long-lived refresh token (used to refresh the access token)",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Error message if the token is invalid or expired",
+                      "example": "Invalid or expired token"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information",
+                      "example": "Verification failed"
+                    }
+                  }
+                },
+                "examples": {
+                  "MissingToken": {
+                    "summary": "Verification token missing",
+                    "value": {
+                      "message": "Verification token is required",
+                      "error": "Missing Token"
+                    }
+                  },
+                  "InvalidToken": {
+                    "summary": "Invalid token",
+                    "value": {
+                      "message": "No email accociated with this token",
+                      "error": "Invalid token"
+                    }
+                  },
+                  "AlreadyVerified": {
+                    "summary": "Already Verified",
+                    "value": {
+                      "message": "Email is already verified",
+                      "error": "Already Verified"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/signin-email": {
+      "post": {
+        "summary": "Sign in using email and password",
+        "description": "This API allows users to sign in using their email and password after verifying their email and creating a password.  \n- On successful authentication, the API provides an **accessToken** and a **refreshToken** for subsequent requests.  \n- If the system has 2FA enabled for the user, the API will provide a temporary token (**token2fa**) instead of the usual tokens.  \n- The user must then complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The user's email address",
+                    "example": "user@example.com"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "The user's password",
+                    "example": "password123"
+                  }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-in successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully authenticated."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "Long-lived refresh token (used to refresh the access token)",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    },
+                    "token2fa": {
+                      "type": "string",
+                      "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                      "example": "U2FsdGVkX1...",
+                      "nullable": true
+                    }
+                  }
+                },
+                "examples": {
+                  "No2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                      "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                    }
+                  },
+                  "With2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Invalid credentials"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Authentication failed"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Invalid credentials",
+                  "error": "Authentication failed"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/signin-social": {
+      "post": {
+        "summary": "Sign in using Google account",
+        "description": "This API allows users to sign in using their Google account.  \n- The user needs to authenticate via Google and provide the **accessToken** returned by Google.  \n- The API will validate the **accessToken** with Google and authenticate the user.  \n- If the system has 2FA enabled for the user, the API will provide a **token2fa** instead of the usual **accessToken** and **refreshToken**.  \n- The user must complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "description": "The social provider used for signing in (e.g., google, facebook)",
+                    "example": "google"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "The OAuth token from the social provider",
+                    "example": "eyJhbGciOiJIUzI1..."
+                  }
+                },
+                "required": [
+                  "provider",
+                  "token"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully authenticated."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "Long-lived refresh token (used to refresh the access token)",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    },
+                    "token2fa": {
+                      "type": "string",
+                      "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                      "example": "U2FsdGVkX1...",
+                      "nullable": true
+                    }
+                  }
+                },
+                "examples": {
+                  "No2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                      "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                    }
+                  },
+                  "With2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Invalid social token"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Authentication failed"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Invalid credentials",
+                  "error": "Authentication failed"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/signout": {
+      "post": {
+        "summary": "Sign out of the system",
+        "description": "This API allows the user to sign out by invalidating the current `accessToken` and `refreshToken`.  \n- The user will be logged out, and the tokens will no longer be valid.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully signed out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully signed out"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while signing out"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Token expired or not authorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "You are not authorized to access this resource. Please log in again."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/refresh-token": {
+      "put": {
+        "summary": "Refresh user authentication token",
+        "description": "This API allows the user to obtain a new access token and refresh token.\n- The user must provide a valid refresh token to get a new access token.\n- This process ensures that the user's session can continue without needing to sign in again.\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refreshToken": {
+                    "type": "string",
+                    "description": "The refresh token provided during sign-in *",
+                    "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                  }
+                },
+                "required": [
+                  "refreshToken"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully refreshed the token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "accessToken": {
+                      "type": "string",
+                      "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "(Optional) A new refresh token, if a new one is issued",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Token expired or not authorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "You are not authorized to access this resource. Please log in again."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/verify-login-2fa": {
+      "post": {
+        "summary": "Verify login with 2FA (token and OTP)",
+        "description": "This API verifies the 2FA during the login process.\n- After successfully logging in with email/password or social sign-in, if 2FA is enabled, the user must provide the 2FA token.\n- The user needs to provide the OTP (One-Time Password) from their authenticator app to complete the login process.\n- The 2FA token is verified and if successful, the user is granted access and provided with JWT tokens (accessToken, refreshToken).\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token2fa": {
+                    "type": "string",
+                    "description": "Encrypted token containing the user data for 2FA.\nThis is used to validate the 2FA during login.\n",
+                    "example": "U2FsdGVkX1..."
+                  },
+                  "otp": {
+                    "type": "string",
+                    "description": "The one-time password (OTP) generated by the authenticator app (e.g., Google Authenticator).\nThis is required to complete the 2FA verification process.\n",
+                    "example": "123456"
+                  }
+                },
+                "required": [
+                  "token2fa",
+                  "otp"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully authenticated."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "description": "JWT access token that the user can use for subsequent requests.",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "JWT refresh token used to get a new access token after expiration.",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid token or OTP",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid 2FA token or OTP."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/send-otp-mobile": {
+      "post": {
+        "summary": "Send OTP for Mobile Signup",
+        "description": "This API initiates the OTP sending process for mobile number signup.\n- Sends an OTP to the specified mobile number via SMS.\n- Requires the mobile country code and mobile number.\n- Generates a temporary token for OTP verification in verify otp mobile endpoint.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mobileCountryCode": {
+                    "type": "string",
+                    "description": "The Mobile Country Code",
+                    "example": "91"
+                  },
+                  "mobile": {
+                    "type": "string",
+                    "example": "9999999999"
+                  },
+                  "captchaRequest": {
+                    "type": "object",
+                    "properties": {
+                      "captcha_id": {
+                        "type": "string",
+                        "example": "c0e8f516d............"
+                      },
+                      "lot_number": {
+                        "type": "string",
+                        "example": "6ab.........................."
+                      },
+                      "pass_token": {
+                        "type": "string",
+                        "example": "3f38860968423............................."
+                      },
+                      "gen_time": {
+                        "type": "string",
+                        "example": "1747994419"
+                      },
+                      "captcha_output": {
+                        "type": "string",
+                        "example": "oJBgOJQXRSOQmiSwTwyXzW93xJfDocY9c_K....................."
+                      }
+                    },
+                    "required": [
+                      "captcha_id",
+                      "lot_number",
+                      "pass_token",
+                      "gen_time",
+                      "captcha_output"
+                    ]
+                  }
+                },
+                "required": [
+                  "mobileCountryCode",
+                  "mobile",
+                  "captchaRequest"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OTP sent successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "OTP sent successfully"
+                    },
+                    "requestToken": {
+                      "type": "string",
+                      "description": "Request Token for OTP verification",
+                      "example": "a1b2c3d4e5f6g7h8"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid mobile number or country code"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "invalidMobile": {
+                    "summary": "Mobile number validation failure",
+                    "value": {
+                      "message": "Unable to send OTP due to validation failures",
+                      "errors": [
+                        {
+                          "field": "mobile",
+                          "message": "Invalid Mobile Number"
+                        },
+                        {
+                          "field": "mobileCountryCode",
+                          "message": "Invalid Mobile Country Code"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": " Otp limit exhausted"
+                    }
+                  }
+                },
+                "examples": {
+                  "otpLimitExhausted": {
+                    "summary": "Otp limit exhausted",
+                    "value": {
+                      "message": "You have reached the maximum OTP request limit. Please try after 2 minutes."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/verify-otp-mobile": {
+      "post": {
+        "summary": "Verify mobile OTP",
+        "description": "This API verifies the OTP sent to a mobile number during the signup process.\n- Requires both the OTP received on mobile and the temporary token from the send-otp api\n- Returns temp token upon successful verification\n- The temp token can be used to retrieve mobile number details during signup\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "otp": {
+                    "type": "string",
+                    "description": "The otp sent to device",
+                    "example": "1234"
+                  },
+                  "requestToken": {
+                    "type": "string",
+                    "description": "Request Token for OTP verification received from send-otp-mobile endpoint",
+                    "example": "cder678uhgvcderijhnbgtu"
+                  }
+                },
+                "required": [
+                  "otp",
+                  "requestToken"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OTP verification successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "OTP verified successfully"
+                    },
+                    "verifiedToken": {
+                      "type": "string",
+                      "description": "Verified token for signup-mobile",
+                      "example": "a1b2c3d4e5f6g7h8"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or expired token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Partner code or app code is invalid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/signup-mobile": {
+      "post": {
+        "summary": "SignUp Mobile",
+        "description": "This API helps users to sign up through their mobile.\n- The request requires the **x-app-code** header for authentication and the Partner Code to associate the customer to a particular partner. The payload includes the mobile number.\n- The mobile number must include the country code.\n- Token after verifing that otp.\n- `deviceDetail` is used to capture device-specific information for additional verification and push notification services.\n- Upon successful execution, the API returns an **authToken** that can be used to authenticate the user.\n- The **authToken** is permanent and needs to be stored securely for future authentication.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "x-app-version",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application version of this user.",
+              "example": "1.0.0"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "verifiedToken": {
+                    "type": "string",
+                    "description": "Verified token received from verify-otp-mobile endpoint.",
+                    "example": "1qsde345tfdxcvbhjuytrewsdvbnhj"
+                  },
+                  "referrerCode": {
+                    "type": "string",
+                    "description": "Referrer Code.",
+                    "example": "ABCD1234"
+                  },
+                  "mobileCountryCode": {
+                    "type": "string",
+                    "description": "Mobile Country Code",
+                    "example": "91"
+                  },
+                  "mobile": {
+                    "type": "string",
+                    "description": "Mobile number of user",
+                    "example": "9999999999"
+                  },
+                  "email": {
+                    "type": "string",
+                    "description": "Email of user",
+                    "example": "jhon@description.com"
+                  },
+                  "deviceDetail": {
+                    "type": "object",
+                    "properties": {
+                      "imei": {
+                        "type": "string",
+                        "description": "The IMEI number of the device.",
+                        "example": "863768093627018/85"
+                      },
+                      "model": {
+                        "type": "string",
+                        "description": "The model of the device.",
+                        "example": "6T"
+                      },
+                      "brand": {
+                        "type": "string",
+                        "description": "The brand of the device.",
+                        "example": "Realme"
+                      },
+                      "sysName": {
+                        "type": "string",
+                        "description": "The operating system of the device.",
+                        "example": "android"
+                      },
+                      "sysVersion": {
+                        "type": "string",
+                        "description": "The operating system version.",
+                        "example": "14"
+                      },
+                      "oneSignalId": {
+                        "type": "string",
+                        "description": "The OneSignal ID for push notifications.",
+                        "example": "b1b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b"
+                      }
+                    },
+                    "required": [
+                      "imei",
+                      "model",
+                      "brand",
+                      "sysName",
+                      "sysVersion",
+                      "oneSignalUserId",
+                      "token"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Authentication successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Authentication successful"
+                    },
+                    "authToken": {
+                      "type": "string",
+                      "example": "57f5671bcc06ser8b6a754c3138cf3854feeff8212535296516e35d56c3da75f:69670cd5b841b1d376e8a845d1475a77"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid APP code"
+                    }
+                  }
+                },
+                "examples": {
+                  "invalidAppcode": {
+                    "summary": "Invalid App code",
+                    "value": {
+                      "message": "Invalid APP code"
+                    }
+                  },
+                  "invalidPartnerCode": {
+                    "summary": "Invalid Partner Code",
+                    "value": {
+                      "message": "Invalid Partner Code"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/signin-mobile": {
+      "post": {
+        "summary": "Sign in using mobile permanent verification code",
+        "description": "This API allows users to sign in using a permanent mobile verification code.   \n- The permanent verification code is issued to the user via the **verify-otp** API after successfully verifying their mobile number.  \n- The user must provide this verification code to authenticate.  \n- If the code is valid, the API will issue an **accessToken** and **refreshToken**.  \n- If the system has 2FA enabled for the user, the API will return a **token2fa** instead of the usual **accessToken** and **refreshToken**.  \n- The user must complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "authToken": {
+                    "type": "string",
+                    "description": "The permanent mobile verification code issued after successful mobile verification via the **verify-otp** API.",
+                    "example": "eyJhbGciOiJIUzI1..."
+                  }
+                },
+                "required": [
+                  "authToken"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully authenticated."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "Long-lived refresh token (used to refresh the access token)",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    },
+                    "token2fa": {
+                      "type": "string",
+                      "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                      "example": "U2FsdGVkX1...",
+                      "nullable": true
+                    }
+                  }
+                },
+                "examples": {
+                  "No2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                      "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                    }
+                  },
+                  "With2FA": {
+                    "value": {
+                      "message": "Successfully authenticated.",
+                      "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Invalid social token"
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Authentication failed"
+                    }
+                  }
+                },
+                "examples": {
+                  "invalidAppcode": {
+                    "summary": "Invalid App code",
+                    "value": {
+                      "message": "Invalid APP code"
+                    }
+                  },
+                  "invalidPartnerCode": {
+                    "summary": "Invalid Partner Code",
+                    "value": {
+                      "message": "Invalid Partner Code"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/send-otp-email": {
+      "post": {
+        "summary": "Send OTP to EMail",
+        "description": "This API generates and sends a One-Time Password (OTP) via mail to the specified email. \n- The request requires the **authentication-token** header for authentication and includes the email in the payload. \n- Upon successful execution, the API sends an email containing an OTP, which must be provided at the **verify-otp-email** endpoint to successfully verify the email address..\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "The email of the user.",
+                    "example": "user@example.com"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "An OTP has been sent to your email address for verification.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "An OTP has been sent to your email address for verification."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Email is required"
+                    }
+                  }
+                },
+                "examples": {
+                  "emailRequired": {
+                    "summary": "Email is required",
+                    "value": {
+                      "message": "Email is required"
+                    }
+                  },
+                  "invalidEmail": {
+                    "summary": "Invalid Email",
+                    "value": {
+                      "message": "Invalid email address."
+                    }
+                  },
+                  "emailVerified": {
+                    "summary": "Email verified",
+                    "value": {
+                      "message": "Email is already verified"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid Bearer code"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/verify-otp-email": {
+      "post": {
+        "summary": "Verify OTP",
+        "description": "This API verifies the One-Time Password (OTP) sent to the specified Email.\n- The request body must include the OTP received from the **verification email** sent via **send-otp-email** endpoint.\n- This API validates the OTP and if successful, email gets verified. \n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "otp": {
+                    "type": "string",
+                    "description": "The OTP to verify.",
+                    "example": "123456"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OTP verified successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Your email address has been successfully verified."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid or expired OTP"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid authtoken"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/captcha-challenge": {
+      "get": {
+        "summary": "Get CAPTCHA configuration",
+        "description": "Initializes Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+        "tags": [
+          "Captcha"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CAPTCHA initialized successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Captcha challenge initialized successfully."
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "success"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "lot_number": {
+                          "type": "string",
+                          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                        },
+                        "captcha_type": {
+                          "type": "string",
+                          "example": "slide"
+                        },
+                        "captcha_output": {
+                          "type": "string",
+                          "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+                        },
+                        "pass_token": {
+                          "type": "string",
+                          "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+                        },
+                        "captcha_id": {
+                          "type": "string",
+                          "example": "fb362ff464a632747b0dd0ea90bab013"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      },
+      "post": {
+        "summary": "Validate CAPTCHA configuration",
+        "description": "Validate Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+        "tags": [
+          "Captcha"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mobile": {
+                    "type": "string",
+                    "example": "9456262167"
+                  },
+                  "captcha_id": {
+                    "type": "string",
+                    "example": "d81db9ghjk82bc8abb8b93a6b24b"
+                  },
+                  "lot_number": {
+                    "type": "string",
+                    "example": "362ff4642747b0dd0ea90bab013ss"
+                  },
+                  "captcha_output": {
+                    "type": "string",
+                    "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+                  },
+                  "pass_token": {
+                    "type": "string",
+                    "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+                  },
+                  "gen_time": {
+                    "type": "string",
+                    "example": "1747751473"
+                  }
+                },
+                "required": [
+                  "mobile",
+                  "captcha_id",
+                  "lot_number",
+                  "captcha_output",
+                  "pass_token",
+                  "gen_time"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "CAPTCHA validated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Captcha validated successfully."
+                    },
+                    "accessToken": {
+                      "type": "string",
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Captcha validation failed."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "pass_token expire"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/generate-2fa": {
+      "get": {
+        "summary": "Generate 2FA secret key and QR code for the user",
+        "description": "This API generates a new 2FA secret key for the user, which can be used with an authenticator app (e.g., Google Authenticator).\nIt also returns the QR code data as a Base64 string, which can be scanned by the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "2FA secret and QR code generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Success message",
+                      "example": "2FA secret generated successfully."
+                    },
+                    "qrCodeData": {
+                      "type": "string",
+                      "description": "QR code image data for scanning",
+                      "example": "data:image/png;base64,iVBORw0..."
+                    },
+                    "secret": {
+                      "type": "string",
+                      "description": "The secret, in case user wants to manually enter it",
+                      "example": "JBSWY3DPEHPK3PXP"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/enable-2fa": {
+      "post": {
+        "summary": "Enable 2FA for the user",
+        "description": "This API enables 2FA for the user by verifying the OTP generated by their authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "token generated by the user's authenticator app",
+                    "example": 123456
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "2FA enabled successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Confirmation message for the user",
+                      "example": "Two-factor authentication enabled successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while enabling two-factor authentication."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Error message if OTP verification fails",
+                      "example": "Invalid OTP. Please try again."
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Error occurred while enabling two-factor authentication.",
+                  "error": "Invalid code or secret"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/verify-2fa": {
+      "post": {
+        "summary": "Verify 2FA OTP for sensitive information access",
+        "description": "This API is used to verify the OTP from the user's authenticator app for sensitive operations such as accessing confidential data.\nThis is a separate verification step and should be used whenever 2FA is required to access specific, sensitive information.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "The one-time password (OTP) sent to the user.",
+                    "example": "123456",
+                    "maxLength": 6,
+                    "minLength": 6
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully authenticated."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid OTP",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid OTP."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/status-2fa": {
+      "get": {
+        "summary": "Retrieve the 2FA status of the user",
+        "description": "This API returns the current 2FA status of the user, indicating whether 2FA is enabled or not.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "2FA status retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "2FA Enabled for this user"
+                    },
+                    "status": {
+                      "type": "boolean",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/disable-2fa": {
+      "put": {
+        "summary": "Disable 2FA for the user",
+        "description": "This API disables 2FA for the user by verifying the OTP from the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Two-Factor Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "2FA disabled successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "2FA disabled successfully"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/create-password": {
+      "post": {
+        "summary": "Create a password for the user after email verification",
+        "description": "This API allows the user to set their password after successfully verifying their email. \nThe user must provide the following details:\n- The **temporary token** received after successful email verification.\n- A new password that will be used to authenticate the user on future logins.\n\nUpon successful creation of the password:\n- The user’s password is saved securely in the system.\n- The account is fully activated, and the user can log in using their new password.\n\nIf the temporary token is invalid or expired:\n- The user will receive an error response indicating the failure.\n- The password creation process will be aborted.\n\nIf the password doesn't meet the required security criteria:\n- The user will be prompted to choose a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Password Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                    "example": "StrongP@ssw0rd123!"
+                  }
+                },
+                "required": [
+                  "password"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Password created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Success message",
+                      "example": "Password created successfully. You can now sign in."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Failed to create a password. Please ensure your token is valid and try again."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                      "example": "weak password"
+                    }
+                  }
+                },
+                "examples": {
+                  "WeakPassword": {
+                    "summary": "Weak Password",
+                    "value": {
+                      "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "error": "Weak Password"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/change-password": {
+      "post": {
+        "summary": "Change the user’s password",
+        "description": "This API allows an authenticated user to change their existing password.\n\nRequirements:\n- The user must provide their current password for verification.\n- A new password that meets the system's security criteria must be provided.\n\nUpon successful password change:\n- The new password will replace the existing password.\n- The user can use the new password for future logins.\n\nIf the current password is incorrect:\n- The user will receive an error response, and the password will not be updated.\n\nIf the new password does not meet security criteria:\n- The user will be prompted to provide a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Password Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "oldPassword": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "The user's current password",
+                    "example": "oldpassword123"
+                  },
+                  "newPassword": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                    "example": "StrongP@ssw0rd123!"
+                  }
+                },
+                "required": [
+                  "oldPassword",
+                  "newPassword"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Password changed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Confirmation message for the user",
+                      "example": "Password changed successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while changing password."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Old password is incorrect"
+                    }
+                  }
+                },
+                "examples": {
+                  "WeakPassword": {
+                    "summary": "Weak Password",
+                    "value": {
+                      "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "error": "Weak Password"
+                    }
+                  },
+                  "IncorrectOldPassword": {
+                    "summary": "Incorrect Old Password",
+                    "value": {
+                      "message": "Old password is incorrect.",
+                      "error": "Incorrect Old Password"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/forgot-password": {
+      "post": {
+        "summary": "Initiate the password reset process",
+        "description": "This API allows a user to request a password reset link or token if they have forgotten their password.\n\nWorkflow:\n- The user provides their registered email address.\n- If the email exists in the system:\n  - A password reset link or token is sent to the provided email.\n  - The user can use this link/token to reset their password.\n- If the email does not exist:\n  - For security purposes, a generic success message is returned (to prevent email enumeration).\n\nThe email will contain:\n- A secure token.\n- Instructions to reset the password.\n\nIf the email sending fails:\n- An error response will be provided.\n\nUpon successful email delivery, the user will receive a confirmation response.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Password Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The user's registered email address",
+                    "example": "user@example.com"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Password reset link sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Confirmation message for the user",
+                      "example": "Password reset link sent to your email."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while sending password reset link."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "User not found"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Error occurred while sending password reset link.",
+                  "error": "User not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "summary": "Reset user password using a valid reset token",
+        "description": "This API allows a user to reset their password using the password reset token received in the password reset email.\nWorkflow:\n- The user provides:\n  - A valid password reset token.\n  - A new password that meets the system’s security criteria.\n- If the token is valid and not expired:\n  - The user's password is securely updated in the system.\n  - The token is invalidated to prevent reuse.\n- If the token is invalid or expired:\n  - An error response is returned.\n\nUpon successful password reset:\n- The user will be able to log in with the new password.\n\nSecurity Considerations:\n- The reset token must be validated for authenticity and expiration.\n- The new password should meet all required security criteria.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Password Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                    "example": "StrongP@ssw0rd123!"
+                  }
+                },
+                "required": [
+                  "password"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Password reset successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Confirmation message for the user",
+                      "example": "Password reset successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Failed to create a password. Please ensure your token is valid and try again."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                      "example": "weak password"
+                    }
+                  }
+                },
+                "examples": {
+                  "WeakPassword": {
+                    "summary": "Weak Password",
+                    "value": {
+                      "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "error": "Weak Password"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/kyc": {
+      "post": {
+        "summary": "Initiate the Customer KYC application",
+        "description": "This API initiates the Customer KYC application process for individual customers.\n\nWorkflow:\n- Accepts customer details such as name, email, and wallet address.\n- Starts the KYC process by registering the customer and assigning a unique KYC ID.\n- The application status is marked as pending until additional steps are completed.\n\nKey Notes:\n- This process is specific to individual customers.\n- The application may require further actions, such as identity verification, uploading documents, etc.\n- Updates regarding the application's progress will be sent to the customer's registered email.\n\nUpon successful initiation:\n- The API returns a success message along with the KYC application status and KYC ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "KYC"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "firstName": {
+                    "type": "string",
+                    "description": "The customer's first name",
+                    "example": "John",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The customer's last name",
+                    "example": "Doe",
+                    "maxLength": 50
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The customer's email address",
+                    "example": "john.doe@example.com"
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "address": {
+                    "type": "object",
+                    "properties": {
+                      "line1": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "city": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "maxLength": 2
+                      },
+                      "country": {
+                        "type": "string",
+                        "maxLength": 50
+                      }
+                    },
+                    "required": [
+                      "line1",
+                      "city",
+                      "countryCode",
+                      "country"
+                    ]
+                  },
+                  "phoneCountryCode": {
+                    "type": "string",
+                    "description": "Customer country code",
+                    "example": 91,
+                    "maxLength": 3
+                  },
+                  "phoneNumber": {
+                    "type": "string",
+                    "description": "phoneNumber",
+                    "example": 9999999999,
+                    "maxLength": 15
+                  },
+                  "occupation": {
+                    "type": "string",
+                    "description": "occupation code fetched from master api",
+                    "example": "11-3011",
+                    "maxLength": 50
+                  },
+                  "annualSalary": {
+                    "type": "number",
+                    "description": "annualSalary",
+                    "example": 4000000
+                  },
+                  "accountPurpose": {
+                    "type": "string",
+                    "description": "accountPurpose",
+                    "example": "Investment",
+                    "maxLength": 15
+                  },
+                  "expectedMonthlySpend": {
+                    "type": "number",
+                    "description": "expectedMonthlySpend",
+                    "example": 10000
+                  },
+                  "walletAddress": {
+                    "type": "string",
+                    "description": "The person's wallet address; required if using the hosted completion flow and a non-custodial solution, but not required otherwise",
+                    "example": "0x1234...abcd"
+                  },
+                  "isTermOfServiceAccepted": {
+                    "type": "boolean",
+                    "description": "is customer accepted all terms of service",
+                    "example": true
+                  },
+                  "isWalletOwner": {
+                    "type": "boolean",
+                    "description": "is customer owner of wallet address",
+                    "example": true
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "walletAddress",
+                  "address",
+                  "ipAddress",
+                  "isTermOfServiceAccepted"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "KYC application initiated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "Indicates the form is in draft mode.",
+                      "example": "Pending",
+                      "enum": [
+                        "PENDING"
+                      ]
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Message providing more information about the draft status.",
+                      "example": "KYC application initiated successfully."
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Unique ID for tracking the draft submission.",
+                      "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "lastUpdated": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "ISO timestamp of the last update.",
+                      "example": "2024-10-14T12:34:56Z"
+                    },
+                    "nextSteps": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "verificationLink": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "example": "https://app-kyc.xyz/kyc"
+                              },
+                              "params": {
+                                "type": "object",
+                                "properties": {
+                                  "userId": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                  },
+                                  "redirect": {
+                                    "type": "string",
+                                    "format": "url",
+                                    "example": "https://app-qa.pay.com/kycConfirmation"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Error message indicating the reason for failure",
+                      "example": "Unable to initiate KYC because of the validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "description": "The field that caused the validation error",
+                            "example": "walletAddress"
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "The validation error message",
+                            "example": "walletAddress must be a valid address"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "missingField": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "message": "Unable to initiate KYC because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "firstName",
+                          "message": "firstName is required"
+                        }
+                      ]
+                    }
+                  },
+                  "invalidEmail": {
+                    "summary": "Invalid email format",
+                    "value": {
+                      "message": "Unable to initiate KYC because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "email",
+                          "message": "email must be a valid email address"
+                        }
+                      ]
+                    }
+                  },
+                  "invalidWalletAddress": {
+                    "summary": "Invalid wallet address",
+                    "value": {
+                      "message": "Unable to initiate KYC because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "walletAddress",
+                          "message": "walletAddress must be a valid address"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/kyc/{id}": {
+      "get": {
+        "summary": "Retrieve Individual customer application details",
+        "description": "This API is used to fetch the details of an existing individual customer application.\n       \nKey Notes:\n- Returns detailed information about the application, including the status and all submitted details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "KYC"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "KYC information retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "A success message for the response.",
+                      "example": "KYC information retrieved successfully."
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The unique ID of the KYC draft.",
+                      "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The first name of the individual user.",
+                      "example": "John",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The last name of the individual user.",
+                      "example": "Doe",
+                      "maxLength": 50
+                    },
+                    "createdOn": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "The date and time when the user registers in the system.",
+                      "example": "2024-10-14T12:34:56Z"
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The email address of the individual user.",
+                      "example": "johndoe@johndoe.com"
+                    },
+                    "address": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string",
+                          "description": "The first line of the address.",
+                          "example": "123, ABC Street",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "description": "The city of the address.",
+                          "example": "XYZ",
+                          "maxLength": 50
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "description": "The country code of the address.",
+                          "example": "IN",
+                          "maxLength": 2,
+                          "minLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "description": "The country of the address.",
+                          "example": "India",
+                          "maxLength": 50
+                        }
+                      }
+                    },
+                    "phoneCountryCode": {
+                      "type": "string",
+                      "description": "The country code of the phone number.",
+                      "example": "91",
+                      "maxLength": 3
+                    },
+                    "phoneNumber": {
+                      "type": "string",
+                      "description": "The phone number of the individual user.",
+                      "example": "1234567890",
+                      "maxLength": 15,
+                      "minLength": 1
+                    },
+                    "badge": {
+                      "type": "object",
+                      "description": "Badge earned by the user based on their activities in the system.",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "description": "Short code for the badge.",
+                          "example": "SupF"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Full name of the badge.",
+                          "example": "SuperFan"
+                        }
+                      }
+                    },
+                    "referralCode": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "referralDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 0.1
+                    },
+                    "referralDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "percentage",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "referralCount": {
+                      "type": "number",
+                      "example": 10
+                    },
+                    "referrerCode": {
+                      "type": "string",
+                      "example": "absdkfjhdsd"
+                    },
+                    "referrerDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 100
+                    },
+                    "referrerDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "flat",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "The wallet address of the individual user.",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "nextSteps": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "verificationLink": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "example": "https://app-kyc.xyz/kyc"
+                              },
+                              "params": {
+                                "type": "object",
+                                "properties": {
+                                  "userId": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                  },
+                                  "redirect": {
+                                    "type": "string",
+                                    "format": "url",
+                                    "example": "https://app-qa.pay.com/kycConfirmation"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "pending": {
+                    "summary": "Pending status with next steps",
+                    "value": {
+                      "message": "KYC information retrieved successfully.",
+                      "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                      "firstName": "User Name",
+                      "lastName": "User Last Name",
+                      "email": "user@kyc.com",
+                      "address": {
+                        "line1": "123, ABC Street",
+                        "city": "XYZ",
+                        "countryCode": "IN",
+                        "country": "India"
+                      },
+                      "phoneCountryCode": "+91",
+                      "phoneNumber": "1234567890",
+                      "occupation": "Business",
+                      "annualSalary": 50000,
+                      "accountPurpose": "Investement",
+                      "expectedMonthlySpend": 10000,
+                      "walletAddress": "0x1234567890",
+                      "status": "pending",
+                      "referralCode": "ABCD1234",
+                      "nextSteps": [
+                        {
+                          "verificationLink": {
+                            "url": "https://www.example.com",
+                            "params": {
+                              "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                              "redirect": "https://app-qa.pay.com/kycConfirmation"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "approved": {
+                    "summary": "Approved status without next steps",
+                    "value": {
+                      "message": "KYC information retrieved successfully.",
+                      "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                      "firstName": "User Name",
+                      "lastName": "User Last Name",
+                      "email": "user@kyc.com",
+                      "address": {
+                        "line1": "123, ABC Street",
+                        "city": "XYZ",
+                        "countryCode": "IN",
+                        "country": "India"
+                      },
+                      "phoneCountryCode": "+91",
+                      "phoneNumber": "1234567890",
+                      "walletAddress": "0x1234567890",
+                      "status": "approved",
+                      "referralCode": "ABCD1234",
+                      "referralCount": 10
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "A general error message.",
+                      "example": "Error occurred while retrieving KYC information."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "A detailed error message for troubleshooting.",
+                      "example": "KYC record not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/kyc/submit/{id}": {
+      "put": {
+        "summary": "Submit a individual customer application for review",
+        "description": "This API is used to submit an individual customer application for review after all verification steps are complete.\n        \n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "KYC"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "KYC information submitted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "KYC information submitted successfully"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Customer not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/kyc/profile": {
+      "get": {
+        "summary": "Retrieve the customer profile details",
+        "description": "This API returns the profile information of the authenticated customer.\n- Returns information related to the customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "KYC"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved user profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "A success message for the response.",
+                      "example": "KYC information retrieved successfully."
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The unique ID of the KYC draft.",
+                      "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The first name of the individual user.",
+                      "example": "John",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The last name of the individual user.",
+                      "example": "Doe",
+                      "maxLength": 50
+                    },
+                    "createdOn": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "The date and time when the user registers in the system.",
+                      "example": "2024-10-14T12:34:56Z"
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The email address of the individual user.",
+                      "example": "johndoe@johndoe.com"
+                    },
+                    "address": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string",
+                          "description": "The first line of the address.",
+                          "example": "123, ABC Street",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "description": "The city of the address.",
+                          "example": "XYZ",
+                          "maxLength": 50
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "description": "The country code of the address.",
+                          "example": "IN",
+                          "maxLength": 2,
+                          "minLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "description": "The country of the address.",
+                          "example": "India",
+                          "maxLength": 50
+                        }
+                      }
+                    },
+                    "phoneCountryCode": {
+                      "type": "string",
+                      "description": "The country code of the phone number.",
+                      "example": "91",
+                      "maxLength": 3
+                    },
+                    "phoneNumber": {
+                      "type": "string",
+                      "description": "The phone number of the individual user.",
+                      "example": "1234567890",
+                      "maxLength": 15,
+                      "minLength": 1
+                    },
+                    "badge": {
+                      "type": "object",
+                      "description": "Badge earned by the user based on their activities in the system.",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "description": "Short code for the badge.",
+                          "example": "SupF"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Full name of the badge.",
+                          "example": "SuperFan"
+                        }
+                      }
+                    },
+                    "referralCode": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "referralDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 0.1
+                    },
+                    "referralDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "percentage",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "referralCount": {
+                      "type": "number",
+                      "example": 10
+                    },
+                    "referrerCode": {
+                      "type": "string",
+                      "example": "absdkfjhdsd"
+                    },
+                    "referrerDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 100
+                    },
+                    "referrerDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "flat",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "The wallet address of the individual user.",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "nextSteps": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "verificationLink": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "example": "https://app-kyc.xyz/kyc"
+                              },
+                              "params": {
+                                "type": "object",
+                                "properties": {
+                                  "userId": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                                  },
+                                  "redirect": {
+                                    "type": "string",
+                                    "format": "url",
+                                    "example": "https://app-qa.pay.com/kycConfirmation"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "individualPending": {
+                    "summary": "Individual customer profile with pending status",
+                    "value": {
+                      "message": "Profile retrieved successfully.",
+                      "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                      "firstName": "User Name",
+                      "lastName": "User Last Name",
+                      "email": "user@kyc.com",
+                      "address": {
+                        "line1": "123, ABC Street",
+                        "city": "XYZ",
+                        "countryCode": "IN",
+                        "country": "India"
+                      },
+                      "phoneCountryCode": "+91",
+                      "phoneNumber": "1234567890",
+                      "occupation": "Business",
+                      "annualSalary": 50000,
+                      "accountPurpose": "Investement",
+                      "expectedMonthlySpend": 10000,
+                      "walletAddress": "0x1234567890",
+                      "status": "pending",
+                      "referralCode": "ABCD1234",
+                      "referrerCode": "AXCY5678",
+                      "nextSteps": [
+                        {
+                          "verificationLink": {
+                            "url": "https://www.example.com",
+                            "params": {
+                              "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                              "redirect": "https://app-qa.pay.com/kycConfirmation"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "individualapproved": {
+                    "summary": "Individual customer profile with approved status",
+                    "value": {
+                      "message": "Profile retrieved successfully.",
+                      "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                      "firstName": "User Name",
+                      "lastName": "User Last Name",
+                      "email": "user@kyc.com",
+                      "address": {
+                        "line1": "123, ABC Street",
+                        "city": "XYZ",
+                        "countryCode": "IN",
+                        "country": "India"
+                      },
+                      "phoneCountryCode": "+91",
+                      "phoneNumber": "1234567890",
+                      "walletAddress": "0x1234567890",
+                      "status": "approved",
+                      "referralCode": "ABCD1234",
+                      "referralDiscount": 0.1,
+                      "referralDiscountType": "percentage",
+                      "referralCount": 10,
+                      "referrerCode": "AXCY5678",
+                      "referrerDiscount": 100,
+                      "referrerDiscountType": "flat",
+                      "badge": {
+                        "code": "SupF",
+                        "name": "SuperFan"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "A general error message for the failed profile retrieval.",
+                      "example": "Error occurred while retrieving the profile."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information to assist in troubleshooting.",
+                      "example": "Profile not found."
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Error occurred while fetching user profile.",
+                  "error": "User not found"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/verification/status": {
+      "get": {
+        "summary": "Retrieve the verification status of a customer application",
+        "description": "This API retrieves the verification status of customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Verification"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the customer application verification status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "pending",
+                      "enum": [
+                        "notStarted",
+                        "pending",
+                        "pendingEmailVerification",
+                        "emailVerified",
+                        "saved",
+                        "needsVerification",
+                        "verificationPending",
+                        "underReview",
+                        "manualReview",
+                        "needsInformation",
+                        "verified",
+                        "rejected",
+                        "cancelled",
+                        "denied",
+                        "locked"
+                      ]
+                    }
+                  }
+                },
+                "examples": {
+                  "corporatePending": {
+                    "summary": "Corporate Customer Pending Status",
+                    "value": {
+                      "status": "pending"
+                    }
+                  },
+                  "corporateUnderReview": {
+                    "summary": "Corporate Customer Under Review Status",
+                    "value": {
+                      "status": "underReview"
+                    }
+                  },
+                  "corporateVerified": {
+                    "summary": "Corporate Customer Verified Status",
+                    "value": {
+                      "status": "verified"
+                    }
+                  },
+                  "individualPending": {
+                    "summary": "Individual Customer Pending Status",
+                    "value": {
+                      "status": "pending"
+                    }
+                  },
+                  "individualPendingEmailVerification": {
+                    "summary": "Individual Customer Pending Email Verification Status",
+                    "value": {
+                      "status": "pendingEmailVerification"
+                    }
+                  },
+                  "individualEmailVerified": {
+                    "summary": "Individual Customer Email Verified Status",
+                    "value": {
+                      "status": "emailVerified"
+                    }
+                  },
+                  "individualSaved": {
+                    "summary": "Individual Customer Saved Status",
+                    "value": {
+                      "status": "saved"
+                    }
+                  },
+                  "individualVerificationPending": {
+                    "summary": "Individual Customer Verification Pending Status",
+                    "value": {
+                      "status": "pending"
+                    }
+                  },
+                  "individualUnderReview": {
+                    "summary": "Individual Customer Under Review Status",
+                    "value": {
+                      "status": "underReview"
+                    }
+                  },
+                  "individualVerified": {
+                    "summary": "Individual Customer Verified Status",
+                    "value": {
+                      "status": "verified"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Status not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "MISSING_INFORMATION"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Additional business details required."
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Status not found.",
+                  "error": "Invalid request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card": {
+      "get": {
+        "summary": "Fetch user cards",
+        "description": "Retrieve a list of all cards associated with the authenticated user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of card to be fetched.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "physical"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "The status of card.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "active"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of cards.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "List of cards retrieved successfully"
+                    },
+                    "cards": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardName": {
+                            "type": "string",
+                            "example": "Regular"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "cardMaterialName": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "isActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "offers": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "example": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe"
+                                },
+                                "code": {
+                                  "type": "string",
+                                  "example": "4561228"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Offer card"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "example": "card",
+                                  "enum": [
+                                    "card"
+                                  ]
+                                },
+                                "value": {
+                                  "type": "number",
+                                  "example": 0
+                                },
+                                "valueType": {
+                                  "type": "string",
+                                  "example": "amount",
+                                  "enum": [
+                                    "amount",
+                                    "percentage"
+                                  ]
+                                },
+                                "hasClaimed": {
+                                  "type": "boolean",
+                                  "example": false
+                                },
+                                "fees": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "example": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223"
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                        "example": "activation",
+                                        "enum": [
+                                          "activation",
+                                          "rental"
+                                        ]
+                                      },
+                                      "label": {
+                                        "type": "string",
+                                        "example": "Card Fee"
+                                      },
+                                      "amount": {
+                                        "type": "number",
+                                        "example": 100
+                                      },
+                                      "interval": {
+                                        "type": "string",
+                                        "example": "lifetime"
+                                      },
+                                      "frequency": {
+                                        "type": "string",
+                                        "example": "one-time"
+                                      },
+                                      "coolOffPeriod": {
+                                        "type": "integer",
+                                        "example": 0
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "displayName": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "orderDate": {
+                            "type": "Date",
+                            "example": "2025-04-23T17:53:52.000Z"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "physicalCard": {
+                    "summary": "Physical card details",
+                    "value": {
+                      "message": "Successfully retrieved user cards.",
+                      "cards": [
+                        {
+                          "id": "344fb823-9949-4401-829a-6e2c87825b10",
+                          "type": "physical",
+                          "status": "notActivated",
+                          "last4Digits": "9678",
+                          "expirationMonth": "01",
+                          "expirationYear": "2029",
+                          "productType": "SIGNATURE",
+                          "productScheme": "VISA",
+                          "productCode": "4578589k",
+                          "cardName": "Regular",
+                          "cardMaterial": "metal",
+                          "cardMaterialName": "Metal",
+                          "isPinActivated": false,
+                          "isActivated": false,
+                          "offers": [
+                            {
+                              "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                              "code": "4561228",
+                              "name": "Offer card",
+                              "type": "card",
+                              "value": 0,
+                              "valueType": "amount",
+                              "hasClaimed": false,
+                              "fees": [
+                                {
+                                  "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "Card Fee",
+                                  "amount": 100,
+                                  "interval": "lifetime",
+                                  "frequency": "one-time",
+                                  "coolOffPeriod": 0
+                                },
+                                {
+                                  "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "Card Fee",
+                                  "amount": 500,
+                                  "interval": "lifetime",
+                                  "frequency": "one-time",
+                                  "coolOffPeriod": 0
+                                }
+                              ]
+                            }
+                          ],
+                          "displayName": "asdasd",
+                          "orderNumber": "263729",
+                          "orderDate": "2025-04-30T13:05:00.000Z"
+                        }
+                      ]
+                    }
+                  },
+                  "virtualCard": {
+                    "summary": "Virtual card details",
+                    "value": {
+                      "message": "Successfully retrieved user cards.",
+                      "cards": [
+                        {
+                          "id": "45e88904-74b9-43b7-9e9b-ff16127078e1",
+                          "type": "virtual",
+                          "status": "active",
+                          "last4Digits": "2839",
+                          "expirationMonth": "03",
+                          "expirationYear": "2029",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "82a7df4f",
+                          "cardName": "Neo Card",
+                          "isPinActivated": false,
+                          "isActivated": false,
+                          "offers": [
+                            {
+                              "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                              "code": "4561228",
+                              "name": "Offer card",
+                              "type": "card",
+                              "value": 0,
+                              "valueType": "amount",
+                              "hasClaimed": false,
+                              "fees": [
+                                {
+                                  "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "Card Fee",
+                                  "amount": 100,
+                                  "interval": "lifetime",
+                                  "frequency": "one-time",
+                                  "coolOffPeriod": 0
+                                },
+                                {
+                                  "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                  "type": "activation",
+                                  "label": "Card Fee",
+                                  "amount": 500,
+                                  "interval": "lifetime",
+                                  "frequency": "one-time",
+                                  "coolOffPeriod": 0
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid request payload."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cards found or user not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "examples": {
+                  "noCards": {
+                    "summary": "No cards found",
+                    "value": {
+                      "message": "No cards found for the user"
+                    }
+                  },
+                  "userNotFound": {
+                    "summary": "User not found",
+                    "value": {
+                      "message": "User not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Add new card",
+        "description": "Add new card for the authenticated user with the provided details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Details to add a card.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "example": "ABCD1234"
+                  },
+                  "coupon": {
+                    "type": "string",
+                    "example": "XYZ1234"
+                  },
+                  "fees": {
+                    "type": "array",
+                    "example": [
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "dispalyName": {
+                    "type": "string",
+                    "example": "John"
+                  },
+                  "cardMaterialCode": {
+                    "type": "string",
+                    "example": "ABCD1234"
+                  },
+                  "shipTo": {
+                    "type": "object",
+                    "properties": {
+                      "firstName": {
+                        "type": "string",
+                        "example": "John"
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "example": "Doe"
+                      },
+                      "line1": {
+                        "type": "string",
+                        "example": "123 Street Name"
+                      },
+                      "line2": {
+                        "type": "string",
+                        "example": "123 Street Name"
+                      },
+                      "city": {
+                        "type": "string",
+                        "example": "Mumbai"
+                      },
+                      "region": {
+                        "type": "string",
+                        "example": "Maharashtra"
+                      },
+                      "postalCode": {
+                        "type": "string",
+                        "example": "400001"
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "example": "IN"
+                      },
+                      "country": {
+                        "type": "string",
+                        "example": "India"
+                      },
+                      "phoneNumber": {
+                        "type": "string",
+                        "example": "9987454512"
+                      }
+                    }
+                  },
+                  "billTo": {
+                    "type": "object",
+                    "properties": {
+                      "line1": {
+                        "type": "string",
+                        "example": "456 Avenue Road"
+                      },
+                      "line2": {
+                        "type": "string",
+                        "example": "123 Street Name"
+                      },
+                      "city": {
+                        "type": "string",
+                        "example": "Delhi"
+                      },
+                      "region": {
+                        "type": "string",
+                        "example": "Delhi"
+                      },
+                      "postalCode": {
+                        "type": "string",
+                        "example": "110001"
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "example": "IN"
+                      },
+                      "country": {
+                        "type": "string",
+                        "example": "India"
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "virtualCard": {
+                  "summary": "Example request for virtual card",
+                  "value": {
+                    "code": "ABCD1234",
+                    "coupon": "XYZ1234",
+                    "fees": [
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                    ]
+                  }
+                },
+                "physicalCard": {
+                  "summary": "Example request for physical card",
+                  "value": {
+                    "code": "ABCD1234",
+                    "coupon": "XYZ1234",
+                    "fees": [
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                      "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3"
+                    ],
+                    "dispalyName": "Jane Doe",
+                    "cardMaterialCode": "MAT-PHY-01",
+                    "shipTo": {
+                      "firstname": "John",
+                      "lastName": "Doe",
+                      "line1": "789 Main Road",
+                      "line2": "Near Metro Station",
+                      "city": "Pune",
+                      "region": "Maharashtra",
+                      "postalCode": "411001",
+                      "countryCode": "IN",
+                      "country": "India",
+                      "phoneNumber": "9874561238"
+                    },
+                    "billTo": {
+                      "line1": "123 Office Lane",
+                      "line2": "Suite 21B",
+                      "city": "Bangalore",
+                      "region": "Karnataka",
+                      "postalCode": "560001",
+                      "countryCode": "IN",
+                      "country": "India"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully added a new card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Successfully added a new card."
+                    },
+                    "card": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "virtual"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Current status of the card.",
+                          "example": "active",
+                          "enum": [
+                            "notActivated",
+                            "active",
+                            "locked",
+                            "canceled"
+                          ]
+                        },
+                        "amount": {
+                          "type": "number",
+                          "description": "Maximum allowable limit for card transactions.",
+                          "example": 1000
+                        },
+                        "frequency": {
+                          "type": "string",
+                          "description": "Usage frequency restrictions on the card.",
+                          "example": "per24HourPeriod",
+                          "enum": [
+                            "per24HourPeriod",
+                            "per7DayPeriod",
+                            "per30DayPeriod",
+                            "perYearPeriod",
+                            "allTime"
+                          ]
+                        },
+                        "last4Digits": {
+                          "type": "string",
+                          "example": "8377"
+                        },
+                        "expirationMonth": {
+                          "type": "string",
+                          "example": "4"
+                        },
+                        "expirationYear": {
+                          "type": "string",
+                          "example": "2030"
+                        },
+                        "productType": {
+                          "type": "string",
+                          "example": "PLATINUM",
+                          "enum": [
+                            "PLATINUM"
+                          ]
+                        },
+                        "productScheme": {
+                          "type": "string",
+                          "example": "VISA",
+                          "enum": [
+                            "VISA"
+                          ]
+                        },
+                        "productCode": {
+                          "type": "string",
+                          "example": "ABCD1234"
+                        },
+                        "cardMaterial": {
+                          "type": "string",
+                          "example": "plastic"
+                        },
+                        "isPinActivated": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "orderNumber": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "cardHolder": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "firstName": {
+                              "type": "string"
+                            },
+                            "lastName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCard": {
+                    "summary": "Virtual card created successfully",
+                    "value": {
+                      "message": "Successfully added a new card.",
+                      "card": {
+                        "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                        "type": "virtual",
+                        "status": "active",
+                        "amount": 1000,
+                        "frequency": "per24HourPeriod",
+                        "last4Digits": "8377",
+                        "expirationMonth": "04",
+                        "expirationYear": "2030",
+                        "productType": "PLATINUM",
+                        "productScheme": "VISA",
+                        "productCode": "ABCD1234",
+                        "isPinActivated": false,
+                        "cardHolder": {
+                          "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                          "firstName": "SJ",
+                          "lastName": "J"
+                        }
+                      }
+                    }
+                  },
+                  "physicalCard": {
+                    "summary": "Physical card created successfully",
+                    "value": {
+                      "message": "Successfully added a new card.",
+                      "card": {
+                        "id": "b345a1ac-a403-4c3f-b334-5b3f676e3822",
+                        "type": "physical",
+                        "status": "notActivated",
+                        "amount": 0,
+                        "frequency": "per24HourPeriod",
+                        "productType": "PLATINUM",
+                        "productScheme": "VISA",
+                        "productCode": "PHYS5678",
+                        "cardMaterial": "plastic",
+                        "isPinActivated": false,
+                        "orderNumber": 1,
+                        "cardHolder": {
+                          "id": "b9123fa1-59e3-4e21-bd6a-9cf10dc12f44",
+                          "firstName": "Jane",
+                          "lastName": "Doe"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided card details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unable to save card because of the validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "status"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "status is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailure": {
+                    "summary": "Validation failure",
+                    "value": {
+                      "message": "Unable to add card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "code",
+                          "message": "Invalid Card Product Code"
+                        },
+                        {
+                          "field": "coupon",
+                          "message": "Invalid Coupon Code"
+                        }
+                      ]
+                    }
+                  },
+                  "FeeDetailValidationFailure": {
+                    "summary": "Fee detail validation failure",
+                    "value": {
+                      "message": "Unable to add card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "fees",
+                          "message": "Fee details are required."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Invalid fee(s) provided."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Invalid fee ID(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3, 114fe929-76e6-4fab-9de3-9a7d6ee9d3d5) provided."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided for the card product."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "activation type fee is required."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Exactly one activation type fee is required."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "rental type fee is required."
+                        },
+                        {
+                          "field": "fees",
+                          "message": "Exactly one rental type fee is required."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{id}": {
+      "get": {
+        "summary": "Retrieve card details",
+        "description": "Fetch detailed information about a specific card using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the card.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Card details retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card details retrieved successfully."
+                    },
+                    "card": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "virtual"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Current status of the card.",
+                          "example": "active",
+                          "enum": [
+                            "notActivated",
+                            "active",
+                            "locked",
+                            "canceled"
+                          ]
+                        },
+                        "amount": {
+                          "type": "number",
+                          "description": "Maximum allowable limit for card transactions.",
+                          "example": 1000
+                        },
+                        "frequency": {
+                          "type": "string",
+                          "description": "Usage frequency restrictions on the card.",
+                          "example": "per24HourPeriod",
+                          "enum": [
+                            "per24HourPeriod",
+                            "per7DayPeriod",
+                            "per30DayPeriod",
+                            "perYearPeriod",
+                            "allTime"
+                          ]
+                        },
+                        "last4Digits": {
+                          "type": "string",
+                          "example": "8377"
+                        },
+                        "expirationMonth": {
+                          "type": "string",
+                          "example": "4"
+                        },
+                        "expirationYear": {
+                          "type": "string",
+                          "example": "2030"
+                        },
+                        "productType": {
+                          "type": "string",
+                          "example": "PLATINUM",
+                          "enum": [
+                            "PLATINUM"
+                          ]
+                        },
+                        "productScheme": {
+                          "type": "string",
+                          "example": "VISA",
+                          "enum": [
+                            "VISA"
+                          ]
+                        },
+                        "productCode": {
+                          "type": "string",
+                          "example": "ABCD1234"
+                        },
+                        "cardMaterial": {
+                          "type": "string",
+                          "example": "plastic"
+                        },
+                        "isPinActivated": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "orderNumber": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "cardHolder": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "68c44898-a805-4d44-8c6d-3e9367343e96"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "example": "Vest"
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "example": "QA"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided card ID is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid card ID"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Modify card details",
+        "description": "Update specific details of a card, such as status or usage restrictions.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the card to be updated.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Details to update for the card.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "frequency": {
+                    "type": "string",
+                    "description": "Usage frequency restrictions on the card.",
+                    "example": "per24HourPeriod",
+                    "enum": [
+                      "per24HourPeriod",
+                      "per7DayPeriod",
+                      "per30DayPeriod",
+                      "perYearPeriod",
+                      "allTime"
+                    ]
+                  },
+                  "amount": {
+                    "type": "number",
+                    "description": "Maximum allowable limit for card transactions.",
+                    "example": 1000
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "Updated status of the card.",
+                    "example": "active",
+                    "enum": [
+                      "notActivated",
+                      "active",
+                      "locked",
+                      "canceled"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated card details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card details updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided card details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unable to save card because of the validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "status"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "status is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailureSample1": {
+                    "value": {
+                      "message": "Unable to save card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "status",
+                          "message": "status is required"
+                        },
+                        {
+                          "field": "amount",
+                          "message": "amount is required"
+                        },
+                        {
+                          "field": "frequency",
+                          "message": "Invalid card frequency"
+                        }
+                      ]
+                    }
+                  },
+                  "validationFailureSample2": {
+                    "value": {
+                      "message": "Unable to save card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "amount",
+                          "message": "Invalid card amount"
+                        },
+                        {
+                          "field": "frequency",
+                          "message": "frequency is required"
+                        }
+                      ]
+                    }
+                  },
+                  "validationFailureSample3": {
+                    "value": {
+                      "message": "Unable to save card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "frequency",
+                          "message": "frequency is required"
+                        },
+                        {
+                          "field": "status",
+                          "message": "Invalid card status"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{id}/activate": {
+      "put": {
+        "summary": "Activate a card",
+        "description": "Mark a card as active using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required only for **physical cards** to verify last 4 digits and expiration details.\n\nFor **virtual cards**, the body should be omitted.\n",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "last4Digits": {
+                    "type": "string",
+                    "description": "Last 4 digits of the physical card.",
+                    "example": "4710"
+                  },
+                  "expirationMonth": {
+                    "type": "string",
+                    "description": "Expiration month of the physical card.",
+                    "example": "10"
+                  },
+                  "expirationYear": {
+                    "type": "string",
+                    "description": "Expiration year of the physical card.",
+                    "example": "2029"
+                  },
+                  "amount": {
+                    "type": "number",
+                    "description": "Amount ( in cents).",
+                    "example": 5000
+                  },
+                  "frequency": {
+                    "type": "string",
+                    "description": "frequency.",
+                    "example": "allTime"
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully activated the card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card activation successfully."
+                    },
+                    "card": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "example": "e65a8911-9feb-44f7-86f8-64cc116d9e9b"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "physical"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "The updated status of the card.",
+                          "example": "active",
+                          "enum": [
+                            "notActivated",
+                            "active",
+                            "locked",
+                            "canceled"
+                          ]
+                        },
+                        "last4Digits": {
+                          "type": "string",
+                          "example": "6922"
+                        },
+                        "expirationMonth": {
+                          "type": "string",
+                          "example": "11"
+                        },
+                        "expirationYear": {
+                          "type": "string",
+                          "example": "2029"
+                        },
+                        "productType": {
+                          "type": "string",
+                          "example": "PLATINUM",
+                          "enum": [
+                            "PLATINUM"
+                          ]
+                        },
+                        "productCode": {
+                          "type": "string",
+                          "example": "4578589k"
+                        },
+                        "cardMaterial": {
+                          "type": "string",
+                          "example": "plastic"
+                        },
+                        "isPinActivated": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "orderNumber": {
+                          "type": "number",
+                          "example": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided card ID is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid card ID"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{id}/secure": {
+      "get": {
+        "summary": "Retrieve secure card details",
+        "description": "Fetch encrypted card information using the card ID and session ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier of the card",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "sessionid",
+            "in": "header",
+            "description": "Base64-encoded session ID of the user requesting the encrypted data",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Secure card details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid card ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid card ID"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/coupon": {
+      "get": {
+        "summary": "Validate coupon code",
+        "description": "Validate a coupon code to check if it is valid and can be applied to a card.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "description": "Partner code of this user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "description": "Application code used for validating mobile-based requests.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          },
+          {
+            "name": "couponCode",
+            "in": "query",
+            "description": "The coupon code to be validated.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "ABCD1234"
+          },
+          {
+            "name": "productCode",
+            "in": "query",
+            "description": "The product code to be validated.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "PROD1234"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Coupon code is valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Coupon code is valid"
+                    },
+                    "coupon": {
+                      "type": "object",
+                      "properties": {
+                        "discount": {
+                          "type": "number",
+                          "description": "Discount value to be applied to the card",
+                          "example": 100
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "Type of discount applied",
+                          "example": "flat",
+                          "enum": [
+                            "percentage",
+                            "flat"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "invalidProductCode": {
+                    "summary": "Invalid product code",
+                    "value": {
+                      "message": "Validation error",
+                      "errors": [
+                        {
+                          "field": "productCode",
+                          "message": "Invalid product code"
+                        }
+                      ]
+                    }
+                  },
+                  "invalidCouponCode": {
+                    "summary": "Invalid coupon code",
+                    "value": {
+                      "message": "Validation error",
+                      "errors": [
+                        {
+                          "field": "couponCode",
+                          "message": "Invalid coupon code."
+                        }
+                      ]
+                    }
+                  },
+                  "couponAlreadyUsed": {
+                    "summary": "Coupon code already used",
+                    "value": {
+                      "message": "Validation error",
+                      "errors": [
+                        {
+                          "field": "couponCode",
+                          "message": "Coupon code already used."
+                        }
+                      ]
+                    }
+                  },
+                  "invalidUserEmail": {
+                    "summary": "Email not associated with coupon code",
+                    "value": {
+                      "message": "Validation error",
+                      "errors": [
+                        {
+                          "field": "userEmail",
+                          "message": "The user email does not registered."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/address": {
+      "get": {
+        "summary": "Get user address for card operations",
+        "description": "Fetches the user's address to be used for card issuance.  \nThe address can originate from either a previously issued card or a completed KYC.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used for validating mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully fetched user address",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "address fetched successfully"
+                    },
+                    "address": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "object",
+                          "properties": {
+                            "firstName": {
+                              "type": "string",
+                              "example": "John"
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "example": "Doe"
+                            },
+                            "city": {
+                              "type": "string",
+                              "example": "Delhi"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "example": "123 Street Name"
+                            },
+                            "line2": {
+                              "type": "string",
+                              "example": "lal chowk"
+                            },
+                            "region": {
+                              "type": "string",
+                              "example": "Delhi"
+                            },
+                            "country": {
+                              "type": "string",
+                              "example": "India"
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "example": "400001"
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "example": "IN"
+                            },
+                            "phoneNumber": {
+                              "type": "string",
+                              "example": "9987339458"
+                            }
+                          }
+                        },
+                        "source": {
+                          "type": "string",
+                          "example": "card",
+                          "enum": [
+                            "card",
+                            "kyc"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "fromCard": {
+                    "summary": "Address from card source",
+                    "value": {
+                      "message": "address fetched successfully",
+                      "address": {
+                        "address": {
+                          "firstName": "John",
+                          "lastName": "Doe",
+                          "city": "Delhi",
+                          "line1": "123 Street Name",
+                          "line2": "lal chowk",
+                          "region": "Delhi",
+                          "country": "India",
+                          "postalCode": "400001",
+                          "countryCode": "IN",
+                          "phoneNumber": "9987339458"
+                        },
+                        "source": "card"
+                      }
+                    }
+                  },
+                  "fromKyc": {
+                    "summary": "Address from KYC source",
+                    "value": {
+                      "message": "address fetched successfully",
+                      "address": {
+                        "address": {
+                          "firstName": "John",
+                          "lastName": "Doe",
+                          "city": "Delhi",
+                          "line1": "123 Street Name",
+                          "line2": "lal chowk",
+                          "region": "Delhi",
+                          "country": "India",
+                          "postalCode": "400001",
+                          "countryCode": "IN"
+                        },
+                        "source": "kyc"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No address found for this user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "No address found for this user"
+                    }
+                  }
+                },
+                "examples": {
+                  "noAddress": {
+                    "summary": "No address saved",
+                    "value": {
+                      "message": "No address found for this user"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/order/{orderNumber}": {
+      "get": {
+        "summary": "Get card order by order ID",
+        "description": "Retrieves detailed information of a card order using the provided order ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used to authenticate mobile-based requests.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          },
+          {
+            "name": "orderNumber",
+            "in": "path",
+            "description": "Unique order ID of the card",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Card fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "card fetched successfully"
+                    },
+                    "card": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "virtual",
+                            "physical"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "notActivated",
+                            "active",
+                            "locked",
+                            "canceled"
+                          ]
+                        },
+                        "last4Digits": {
+                          "type": "string"
+                        },
+                        "expirationMonth": {
+                          "type": "integer"
+                        },
+                        "expirationYear": {
+                          "type": "integer"
+                        },
+                        "productType": {
+                          "type": "string",
+                          "enum": [
+                            "PLATINUM"
+                          ]
+                        },
+                        "productScheme": {
+                          "type": "string",
+                          "enum": [
+                            "VISA",
+                            "MASTERCARD"
+                          ]
+                        },
+                        "productCode": {
+                          "type": "string",
+                          "example": "ABCSG"
+                        },
+                        "cardMaterial": {
+                          "type": "string",
+                          "example": "plastic"
+                        },
+                        "isPinActivated": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "orderNumber": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "fees": {
+                          "type": "object",
+                          "properties": {
+                            "fees": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "coupon": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "shipTo": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "firstName": {
+                              "type": "string"
+                            },
+                            "lastName": {
+                              "type": "string"
+                            },
+                            "city": {
+                              "type": "string"
+                            },
+                            "line1": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "country": {
+                              "type": "string"
+                            },
+                            "postalCode": {
+                              "type": "string"
+                            },
+                            "countryCode": {
+                              "type": "string"
+                            },
+                            "phoneNumber": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "billTo": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "city": {
+                              "type": "string"
+                            },
+                            "line1": {
+                              "type": "string"
+                            },
+                            "line2": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "country": {
+                              "type": "string"
+                            },
+                            "postalCode": {
+                              "type": "string"
+                            },
+                            "countryCode": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "physicalCard": {
+                    "summary": "Physical card order",
+                    "value": {
+                      "message": "card fetched successfully",
+                      "card": {
+                        "id": "36da5b3b-f836-467c-aca9-d2de48248ce5",
+                        "type": "physical",
+                        "status": "notActivated",
+                        "last4Digits": "5817",
+                        "expirationMonth": 7,
+                        "expirationYear": 2029,
+                        "productType": "PLATINUM",
+                        "productScheme": "VISA",
+                        "productCode": "4578589k",
+                        "cardMaterial": "metal",
+                        "isPinActivated": false,
+                        "orderNumber": "000001",
+                        "fees": {
+                          "fees": [],
+                          "coupon": null
+                        },
+                        "shipTo": {
+                          "firstName": "John",
+                          "lastName": "Doe",
+                          "city": "Mumbai",
+                          "line1": "123 Street Name",
+                          "line2": "123 Street Name",
+                          "region": "Maharashtra",
+                          "country": "India",
+                          "postalCode": "400001",
+                          "countryCode": "IN",
+                          "phoneNumber": "9987339458"
+                        },
+                        "billTo": {
+                          "city": "Delhi",
+                          "line1": "456 Avenue Road",
+                          "line2": "456 Avenue Road",
+                          "region": "Delhi",
+                          "country": "India",
+                          "postalCode": "110001",
+                          "countryCode": "IN"
+                        }
+                      }
+                    }
+                  },
+                  "virtualCard": {
+                    "summary": "Virtual card order",
+                    "value": {
+                      "message": "card fetched successfully",
+                      "card": {
+                        "id": "98ad4df2-7c69-432b-9fb7-d9dc128ac250",
+                        "type": "virtual",
+                        "status": "active",
+                        "last4Digits": "4021",
+                        "expirationMonth": 6,
+                        "expirationYear": 2030,
+                        "productType": "PLATINUM",
+                        "productScheme": "VISA",
+                        "productCode": "VIRT8901",
+                        "orderNumber": "000007",
+                        "isPinActivated": true,
+                        "fees": {
+                          "fees": [],
+                          "coupon": null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cards found or user not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "examples": {
+                  "noCards": {
+                    "summary": "No cards found",
+                    "value": {
+                      "message": "card not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{id}/pin": {
+      "put": {
+        "summary": "Update Card PIN",
+        "description": "Update the encrypted PIN of a card using its unique identifier.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          },
+          {
+            "name": "sessionid",
+            "in": "header",
+            "description": "Base64-encoded session ID of the user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique ID of the card to update PIN for",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "iv": {
+                    "type": "string",
+                    "description": "Initialization vector used for PIN encryption",
+                    "example": "wsZy5F3XAxgziyAolEiqRA=="
+                  },
+                  "pin": {
+                    "type": "string",
+                    "description": "Encrypted PIN value",
+                    "example": "cvbABC618qTW+vDSBH6c1ApKy6xDO2hQ5MQt9dYCDhc="
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Card PIN updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card PIN updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid card ID or request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid card ID or PIN format"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Card not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{offerId}/claim": {
+      "get": {
+        "summary": "Get claimable cards for a given offer",
+        "description": "Fetches a list of claimable cards for a user based on the specified offer ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for mobile-based authentication.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          },
+          {
+            "name": "offerId",
+            "in": "path",
+            "description": "Unique identifier of the offer",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Claimable cards fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Claimable cards fetched successfully"
+                    },
+                    "cards": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "scheme": {
+                            "type": "string",
+                            "example": "VISA"
+                          },
+                          "code": {
+                            "type": "string",
+                            "example": "05b0cb49"
+                          },
+                          "label": {
+                            "type": "string",
+                            "example": "LQUID PLATINUM"
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%"
+                          },
+                          "fees": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "amount": {
+                                  "type": "number"
+                                },
+                                "coolOffPeriod": {
+                                  "type": "number"
+                                },
+                                "frequency": {
+                                  "type": "string"
+                                },
+                                "interval": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "cardMaterial": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "fees": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "amount": {
+                                      "type": "number"
+                                    },
+                                    "coolOffPeriod": {
+                                      "type": "number"
+                                    },
+                                    "frequency": {
+                                      "type": "string"
+                                    },
+                                    "interval": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCardExample": {
+                    "summary": "Virtual card with base activation fee",
+                    "value": {
+                      "message": "Claimable cards fetched successfully",
+                      "cards": [
+                        {
+                          "type": "virtual",
+                          "scheme": "VISA",
+                          "code": "05b0cb49",
+                          "label": "LQUID PLATINUM",
+                          "description": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%",
+                          "fees": [
+                            {
+                              "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                              "type": "activation",
+                              "label": "Card Fee",
+                              "amount": 0,
+                              "coolOffPeriod": 0,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            }
+                          ],
+                          "cardMaterial": []
+                        }
+                      ]
+                    }
+                  },
+                  "physicalCardExample": {
+                    "summary": "Physical card with multiple card material fee options",
+                    "value": {
+                      "message": "Claimable cards fetched successfully",
+                      "cards": [
+                        {
+                          "type": "physical",
+                          "scheme": "VISA",
+                          "code": "73c436a7",
+                          "label": "LQUID CHOICE",
+                          "description": "Single transaction limit: $100,000 \\n Cash back on spending of referred users: 0.3%",
+                          "fees": [
+                            {
+                              "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                              "type": "activation",
+                              "label": "Card Fee",
+                              "amount": 0,
+                              "coolOffPeriod": 0,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            }
+                          ],
+                          "cardMaterial": [
+                            {
+                              "code": "plastic",
+                              "name": "plastic",
+                              "fees": {
+                                "id": "8af5a4c8-f02e-11ef-a4ff-06d39f4fa223",
+                                "type": "activation",
+                                "label": "Card Fee",
+                                "amount": 1000,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            },
+                            {
+                              "code": "metal",
+                              "name": "metal",
+                              "fees": {
+                                "id": "45b11804-23ff-11f0-a26c-06d39f4fa223",
+                                "type": "activation",
+                                "label": "One-Time fee for plastic cards",
+                                "amount": 0,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No claimable cards found for this offer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "No claimable cards found for this offer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/card/{id}/claim": {
+      "post": {
+        "summary": "Claim a Card (Virtual or Physical)",
+        "description": "Allows a user to claim a virtual or physical card using an offer. The request payload varies depending on the card type.\n",
+        "tags": [
+          "Card Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the user or session claiming the card.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "offerId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "0d24f14e-2ca3-4f2e-8900-73cda36f335c"
+                  },
+                  "code": {
+                    "type": "string",
+                    "example": "82a7df4f"
+                  },
+                  "fees": {
+                    "type": "array",
+                    "example": [
+                      "dcaece42-0ba8-11f0-a26c-06d39f4fa223"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "example": "asdasd"
+                  },
+                  "cardMaterialCode": {
+                    "type": "string",
+                    "example": "metal"
+                  },
+                  "shipTo": {
+                    "type": "object",
+                    "properties": {
+                      "firstName": {
+                        "type": "string"
+                      },
+                      "lastName": {
+                        "type": "string"
+                      },
+                      "line1": {
+                        "type": "string"
+                      },
+                      "line2": {
+                        "type": "string"
+                      },
+                      "city": {
+                        "type": "string"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "postalCode": {
+                        "type": "string"
+                      },
+                      "countryCode": {
+                        "type": "string"
+                      },
+                      "country": {
+                        "type": "string"
+                      },
+                      "phoneNumber": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "billTo": {
+                    "type": "object",
+                    "properties": {
+                      "line1": {
+                        "type": "string"
+                      },
+                      "city": {
+                        "type": "string"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "postalCode": {
+                        "type": "string"
+                      },
+                      "countryCode": {
+                        "type": "string"
+                      },
+                      "country": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "virtualCard": {
+                  "summary": "Virtual card claim request",
+                  "value": {
+                    "offerId": "0d24f14e-2ca3-4f2e-8900-73cda36f335c",
+                    "code": "82a7df4f",
+                    "fees": [
+                      "dcaece42-0ba8-11f0-a26c-06d39f4fa223"
+                    ]
+                  }
+                },
+                "physicalCard": {
+                  "summary": "Physical card claim request",
+                  "value": {
+                    "offerId": "0d24f14e-2ca3-4f2e-8900-73cda36f335c",
+                    "code": "4578589l",
+                    "fees": [
+                      "dcaece42-0ba8-11f0-a26c-06d39f4fa223",
+                      "78a54dc0-2101-11f0-99a4-0242ac11000f"
+                    ],
+                    "displayName": "asdasd",
+                    "cardMaterialCode": "metal",
+                    "shipTo": {
+                      "firstName": "John",
+                      "lastName": "Doe",
+                      "line1": "123 Street Name",
+                      "line2": "lal chowk 1",
+                      "city": "Delhi",
+                      "region": "Delhi",
+                      "postalCode": "400001",
+                      "countryCode": "IN",
+                      "country": "India",
+                      "phoneNumber": "9987339458"
+                    },
+                    "billTo": {
+                      "line1": "456 Avenue Road",
+                      "city": "mumbai",
+                      "region": "mumbai",
+                      "postalCode": "110001",
+                      "countryCode": "IN",
+                      "country": "India"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Card created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Card created successfully."
+                    },
+                    "card": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "number"
+                        },
+                        "frequency": {
+                          "type": "string"
+                        },
+                        "last4Digits": {
+                          "type": "string"
+                        },
+                        "expirationMonth": {
+                          "type": "string"
+                        },
+                        "expirationYear": {
+                          "type": "string"
+                        },
+                        "cardProduct": {
+                          "type": "string"
+                        },
+                        "cardScheme": {
+                          "type": "string"
+                        },
+                        "cardCode": {
+                          "type": "string"
+                        },
+                        "isPinActivated": {
+                          "type": "boolean"
+                        },
+                        "orderNumber": {
+                          "type": "string"
+                        },
+                        "cardHolder": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "firstName": {
+                              "type": "string"
+                            },
+                            "lastName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCard": {
+                    "summary": "Successful virtual card creation",
+                    "value": {
+                      "message": "Card created successfully.",
+                      "card": {
+                        "id": "29eff3eb-97a5-48a4-945a-343aabea3869",
+                        "type": "virtual",
+                        "status": "active",
+                        "amount": 500,
+                        "frequency": "per24HourPeriod",
+                        "last4Digits": "0000",
+                        "expirationMonth": "00",
+                        "expirationYear": "0000",
+                        "cardProduct": "SIGNATURE",
+                        "cardScheme": "VISA",
+                        "cardCode": "4578589l",
+                        "isPinActivated": false,
+                        "cardHolder": {
+                          "id": "e9b63297-3d39-4e49-911c-23bdd0894030",
+                          "firstName": "VishalApproved",
+                          "lastName": "Gupta"
+                        }
+                      }
+                    }
+                  },
+                  "physicalCard": {
+                    "summary": "Successful physical card creation",
+                    "value": {
+                      "message": "Card created successfully.",
+                      "card": {
+                        "id": "bb35ca06-1f4e-451a-a2a7-4644f2b409d0",
+                        "type": "physical",
+                        "status": "notActivated",
+                        "amount": 0,
+                        "frequency": "per24HourPeriod",
+                        "cardProduct": "SIGNATURE",
+                        "cardScheme": "VISA",
+                        "cardCode": "4578589l",
+                        "isPinActivated": false,
+                        "orderNumber": "951807",
+                        "cardHolder": {
+                          "id": "e9b63297-3d39-4e49-911c-23bdd0894030",
+                          "firstName": "VishalApproved",
+                          "lastName": "Gupta"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error during card claim",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unable to Claim card because of the validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "alreadyClaimed": {
+                    "summary": "Offer already used",
+                    "value": {
+                      "message": "Unable to Claim card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "offerId",
+                          "message": "This card has already been claimed"
+                        }
+                      ]
+                    }
+                  },
+                  "missingPhysicalFields": {
+                    "summary": "Missing fields for physical card",
+                    "value": {
+                      "message": "Unable to Create card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "shipTo",
+                          "message": "shipTo is required"
+                        },
+                        {
+                          "field": "cardMaterialCode",
+                          "message": "cardMaterialCode is required"
+                        },
+                        {
+                          "field": "displayName",
+                          "message": "displayName is required"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User or offer not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Offer or user not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/masterdata/{type}": {
+      "get": {
+        "summary": "Get master data by type",
+        "description": "Retrieve the list of master data by type. Supported types:\n  - **Country**: Returns a list of countries with codes and names.\n  - **DocumentType**: Returns document types available in the system.\n  - **DepositToken**: Returns a list of tokens associated with blockchains.\n  - **CardStatus**: Returns status information for various card types.\n  - **CardProduct**: Returns card product types available in the system.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Master Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "type",
+            "in": "path",
+            "description": "Type of master data to retrieve (e.g., **Country**, **DepositToken**, **CardStatus**, **UserRole**, **CardProduct**, **Consent**).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Country",
+                "DocumentType",
+                "DepositToken",
+                "CardStatus",
+                "UserRole",
+                "CardProduct",
+                "Consent"
+              ]
+            }
+          },
+          {
+            "name": "keyType",
+            "in": "query",
+            "description": "Optional key type to filter the master data.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of master data by type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "description": "Response when type is `Country`",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country_name": {
+                            "type": "string"
+                          },
+                          "country_code": {
+                            "type": "string"
+                          },
+                          "country_code_alpha3": {
+                            "type": "string"
+                          },
+                          "country_mobile_code": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "description": "Response when type is `DocumentType`",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "description": "Response when type is `DepositToken`",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "chainId": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "logo": {
+                            "type": "string"
+                          },
+                          "tokens": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "symbol": {
+                                  "type": "string"
+                                },
+                                "address": {
+                                  "type": "string"
+                                },
+                                "logo": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "description": "Response when type is `CardStatus`",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "isActive": {
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "array",
+                      "description": "Response when type is `CardProduct`",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "scheme": {
+                            "type": "string"
+                          },
+                          "code": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "fees": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "amount": {
+                                  "type": "number"
+                                },
+                                "coolOffPeriod": {
+                                  "type": "number",
+                                  "description": "Number of days for cooling off period"
+                                },
+                                "frequency": {
+                                  "type": "string",
+                                  "description": "Frequency of the fee",
+                                  "enum": [
+                                    "one-time",
+                                    "recurring"
+                                  ]
+                                },
+                                "interval": {
+                                  "type": "string",
+                                  "description": "Interval of the fee",
+                                  "enum": [
+                                    "lifetime",
+                                    "monthly",
+                                    "yearly"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "cardMaterial": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "fees": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "amount": {
+                                      "type": "number"
+                                    },
+                                    "coolOffPeriod": {
+                                      "type": "number"
+                                    },
+                                    "frequency": {
+                                      "type": "string",
+                                      "enum": [
+                                        "one-time",
+                                        "recurring"
+                                      ]
+                                    },
+                                    "interval": {
+                                      "type": "string",
+                                      "enum": [
+                                        "none",
+                                        "lifetime",
+                                        "monthly",
+                                        "yearly"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "Country": {
+                    "summary": "Example response for Country type",
+                    "value": [
+                      {
+                        "country_name": "Dummyland",
+                        "country_code": "DL",
+                        "country_code_alpha3": "DUM",
+                        "country_mobile_code": "76"
+                      },
+                      {
+                        "country_name": "Testistan",
+                        "country_code": "TS",
+                        "country_code_alpha3": "TST",
+                        "country_mobile_code": "56"
+                      },
+                      {
+                        "country_name": "Mockland",
+                        "country_code": "ML",
+                        "country_code_alpha3": "MOK",
+                        "country_mobile_code": "35"
+                      }
+                    ]
+                  },
+                  "DocumentType": {
+                    "summary": "Example response for DocumentType",
+                    "value": [
+                      {
+                        "type": "DocumentType",
+                        "key": "MOCK_ID",
+                        "value": "Mock Identification",
+                        "isActive": true,
+                        "id": "11111111-1111-1111-1111-111111111111"
+                      },
+                      {
+                        "type": "DocumentType",
+                        "key": "TEST_DOC",
+                        "value": "Test Document",
+                        "isActive": true,
+                        "id": "22222222-2222-2222-2222-222222222222"
+                      },
+                      {
+                        "type": "DocumentType",
+                        "key": "DUMMY_CERT",
+                        "value": "Dummy Certificate",
+                        "isActive": false,
+                        "id": "33333333-3333-3333-3333-333333333333"
+                      }
+                    ]
+                  },
+                  "DepositToken": {
+                    "summary": "Example response for DepositToken",
+                    "value": [
+                      {
+                        "chainId": 99999,
+                        "name": "Test Chain Network",
+                        "logo": "https://example.com/test-chain.png",
+                        "tokens": [
+                          {
+                            "name": "Test Coin",
+                            "symbol": "TEST",
+                            "address": "0x1111111111111111111111111111111111111111",
+                            "logo": "https://example.com/test-coin.png"
+                          },
+                          {
+                            "name": "Mock Token",
+                            "symbol": "MOCK",
+                            "address": "0x2222222222222222222222222222222222222222",
+                            "logo": "https://example.com/mock-token.png"
+                          }
+                        ]
+                      },
+                      {
+                        "chainId": 88888,
+                        "name": "Mock Chain Network",
+                        "logo": "https://example.com/mock-chain.png",
+                        "tokens": [
+                          {
+                            "name": "Dummy Coin",
+                            "symbol": "DUMMY",
+                            "address": "0x3333333333333333333333333333333333333333",
+                            "logo": "https://example.com/dummy-coin.png"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "CardStatus": {
+                    "summary": "Example response for CardStatus",
+                    "value": [
+                      {
+                        "type": "CardStatus",
+                        "key": "test_status",
+                        "value": "Test Status",
+                        "isActive": true,
+                        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                      },
+                      {
+                        "type": "CardStatus",
+                        "key": "mock_status",
+                        "value": "Mock Status",
+                        "isActive": true,
+                        "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                      },
+                      {
+                        "type": "CardStatus",
+                        "key": "dummy_status",
+                        "value": "Dummy Status",
+                        "isActive": false,
+                        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                      }
+                    ]
+                  },
+                  "CardProductType": {
+                    "summary": "Example response for Card Product",
+                    "value": [
+                      {
+                        "type": "PLATINUM",
+                        "scheme": "VISA",
+                        "code": "ABCD1234",
+                        "label": "Platinum Rewards Card",
+                        "description": "Earn 2x points on every purchase",
+                        "fees": [
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                            "type": "activation",
+                            "label": "Joining Fees",
+                            "amount": 49900,
+                            "coolOffPeriod": 30,
+                            "frequency": "one-time",
+                            "interval": "lifetime"
+                          },
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                            "type": "rental",
+                            "label": "Monthly Fees",
+                            "amount": 25900,
+                            "coolOffPeriod": 31,
+                            "frequency": "recurring",
+                            "interval": "monthly"
+                          },
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                            "type": "rental",
+                            "label": "Yearly Fees",
+                            "amount": 99900,
+                            "coolOffPeriod": 31,
+                            "frequency": "recurring",
+                            "interval": "yearly"
+                          }
+                        ],
+                        "cardMaterial": [
+                          {
+                            "code": "metal",
+                            "name": "Metal",
+                            "fees": {
+                              "id": "79e9a063-2101-11f0-99a4-0242ac110005",
+                              "type": "activation",
+                              "label": "Premium Metal Card Fee",
+                              "amount": 250,
+                              "coolOffPeriod": 0,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            }
+                          },
+                          {
+                            "code": "semi-metal",
+                            "name": "Semi-metal",
+                            "fees": {
+                              "id": "c0566eee-2101-11f0-99a4-0242ac110005",
+                              "type": "activation",
+                              "label": "Premium Metal Card Fee",
+                              "amount": 250,
+                              "coolOffPeriod": 0,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            }
+                          },
+                          {
+                            "code": "plastic",
+                            "name": "Plastic",
+                            "fees": {
+                              "id": "78a54dc0-2101-11f0-99a4-0242ac110005",
+                              "type": "activation",
+                              "label": "Premium Metal Card Fee",
+                              "amount": 250,
+                              "coolOffPeriod": 0,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "Consent": {
+                    "summary": "Example response for Consent",
+                    "value": [
+                      {
+                        "id": "3c9faeb4-30fc-4bbf-8890-e8beec565407",
+                        "type": "signup",
+                        "message": "I accept the Consent",
+                        "isMandatory": true,
+                        "isActive": true
+                      },
+                      {
+                        "id": "8217bf6b-bc1c-4272-864f-bc721e3d1771",
+                        "type": "signup",
+                        "message": "I certify that the information.",
+                        "isMandatory": true,
+                        "isActive": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid master data type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid master data type"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/masterdata/occupation": {
+      "get": {
+        "summary": "Get consumer occupations or corporate industry",
+        "description": "Retrieve a list of consumer occupations or corporate industry.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Master Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "description": "Partner code associated with the request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89DE4F"
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "description": "Application code for validating mobile requests.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - A list of matching consumer occupations.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "description": "Represents a consumer occupation entry.",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "description": "Unique code identifier for the occupation.",
+                        "example": "11-3011"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "The name of the occupation.",
+                        "example": "Administrative Services Managers"
+                      },
+                      "isActive": {
+                        "type": "boolean",
+                        "description": "Indicates if the occupation record is currently active.",
+                        "example": true
+                      }
+                    },
+                    "required": [
+                      "code",
+                      "name",
+                      "isActive"
+                    ]
+                  }
+                },
+                "example": [
+                  {
+                    "code": "11-3011",
+                    "name": "Administrative Services Managers",
+                    "isActive\"": true
+                  },
+                  {
+                    "code": "11-2011",
+                    "name": "Advertising and Promotions Managers",
+                    "isActive": true
+                  },
+                  {
+                    "code": "13-1011",
+                    "name": "Agents and Business Managers of Artists, Performer",
+                    "isActive": true
+                  }
+                ]
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/wallet/deposit": {
+      "get": {
+        "summary": "Retrieve deposit information for the customer",
+        "description": "This API returns deposit details for the authenticated customer.\n- Returns deposits made under the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deposit information retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "chainId": {
+                        "type": "number"
+                      },
+                      "proxyAddress": {
+                        "type": "string"
+                      },
+                      "proxyAddressQrCode": {
+                        "type": "string",
+                        "description": "QR code image data for proxyAddress",
+                        "example": "data:image/png;base64,iVBORw0..."
+                      },
+                      "tokens": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Deposit information not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Deposit information not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/wallet/balance": {
+      "get": {
+        "summary": "Retrieve wallet balance for the customer",
+        "description": "This API returns the current wallet balance for the authenticated customer. The response includes:\n  - Returns the balance for the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet balance retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "balanceDue": {
+                      "type": "number"
+                    },
+                    "creditLimit": {
+                      "type": "number"
+                    },
+                    "pendingCharges": {
+                      "type": "number"
+                    },
+                    "postedCharges": {
+                      "type": "number"
+                    },
+                    "spendingPower": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Balance information not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Balance information not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/wallet/withdrawal": {
+      "get": {
+        "summary": "Retrieve withdrawal detail for the customer",
+        "description": "This API returns the current withdrawal detail for the authenticated customer. The response includes:\n  - Controller address\n  - Withdrawal fee\n  - Balance information based on available token address\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "chainId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Chain Id for getting the withdrawal detail",
+              "example": 84532
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Withdrawal details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "controllerAddress": {
+                      "type": "string",
+                      "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                    },
+                    "controllerContractAbi": {
+                      "type": "array",
+                      "example": []
+                    },
+                    "fees": {
+                      "type": "number",
+                      "description": "Withdrawal fee in cents",
+                      "example": 100
+                    },
+                    "bundlerUrl": {
+                      "type": "string",
+                      "example": "https://bundler.biconomy.io/api/v3/98765/xYzAbC9de.123a456b-78cd-90ef-12gh-345ijklm6789"
+                    },
+                    "paymasterUrl": {
+                      "type": "string",
+                      "example": "https://paymaster.biconomy.io/api/v2/98765/gH2klmNpQ.1a2b3c4d-5e6f-7890-gh12-ijk34lm56789"
+                    },
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "address": {
+                            "type": "string",
+                            "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                          },
+                          "balance": {
+                            "type": "number",
+                            "example": 50
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ChainId is Invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "chainId"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "chainId is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailure": {
+                    "summary": "Validation failure",
+                    "value": {
+                      "message": "Unable to get withdrawal detail because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "chainId",
+                          "message": "Invalid chainId"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Withdrawal information not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Balance information not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "To generate withdrawal signature",
+        "description": "This API allows the authenticated customer for generating a withdrawal signature using chainId, token, amount and recipient address.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "chainId": {
+                    "type": "integer",
+                    "description": "The chain ID where the smart contract is deployed.",
+                    "example": 1
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "The address of the token to withdraw, as a hex string.",
+                    "example": "0x1234567890abcdef1234567890abcdef12345678"
+                  },
+                  "amount": {
+                    "type": "integer",
+                    "description": "The amount of the token to withdraw.",
+                    "example": 100
+                  },
+                  "recipientAddress": {
+                    "type": "string",
+                    "description": "The address to which the withdrawal should be sent, as a hex string.",
+                    "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Withdrawal signature retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "example": "Withdrawal signature retrieved successfully"
+                        },
+                        "withdrawalId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "example": "996a751b-c47f-45c3-98f4-04afa9ce9a80"
+                        },
+                        "status": {
+                          "type": "string",
+                          "example": "Success"
+                        },
+                        "retryCount": {
+                          "type": "integer",
+                          "example": 0
+                        },
+                        "signature": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "type": "string",
+                              "example": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c"
+                            },
+                            "salt": {
+                              "type": "string",
+                              "example": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                            }
+                          }
+                        },
+                        "expiresAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2025-01-31T04:52:45.000Z"
+                        },
+                        "senders": {
+                          "type": "string",
+                          "example": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931"
+                        },
+                        "parameters": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string",
+                                "example": "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F"
+                              },
+                              {
+                                "type": "integer",
+                                "example": 2410000
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "example": [
+                                    57,
+                                    154,
+                                    15,
+                                    14,
+                                    48,
+                                    237,
+                                    226,
+                                    36,
+                                    148,
+                                    245,
+                                    242,
+                                    152,
+                                    252,
+                                    31,
+                                    203,
+                                    51,
+                                    88,
+                                    107,
+                                    251,
+                                    170,
+                                    118,
+                                    162,
+                                    229,
+                                    236,
+                                    51,
+                                    56,
+                                    254,
+                                    18,
+                                    26,
+                                    46,
+                                    81,
+                                    126
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "signatureReady": {
+                    "summary": "Signature Ready",
+                    "value": {
+                      "message": "Withdrawal signature retrieved successfully",
+                      "withdrawalId": "996a751b-c47f-45c3-98f4-04afa9ce9a80",
+                      "status": "Success",
+                      "retryCount": 0,
+                      "signature": {
+                        "data": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c",
+                        "salt": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                      },
+                      "expiresAt": "2025-01-31T04:52:45.000Z",
+                      "senders": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931",
+                      "parameters": [
+                        "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F",
+                        "0x29684075a3C86ea11D9964BcAf0F956e801396bD",
+                        2410000,
+                        "0x67AC51b706b7f34cA7D966203aD904bE85762623",
+                        1738299165,
+                        [
+                          57,
+                          154,
+                          15,
+                          14,
+                          48,
+                          237,
+                          226,
+                          36,
+                          148,
+                          245,
+                          242,
+                          152,
+                          252,
+                          31,
+                          203,
+                          51,
+                          88,
+                          107,
+                          251,
+                          170,
+                          118,
+                          162,
+                          229,
+                          236,
+                          51,
+                          56,
+                          254,
+                          18,
+                          26,
+                          46,
+                          81,
+                          126
+                        ]
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "status"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "status is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailure": {
+                    "summary": "Validation failure",
+                    "value": {
+                      "message": "Unable to get signature because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "chain Id",
+                          "message": "Invalid Chain Id"
+                        },
+                        {
+                          "field": "admin adress ",
+                          "message": "Invalid Admin Address"
+                        },
+                        {
+                          "field": "amount",
+                          "message": "Invalid Amount"
+                        },
+                        {
+                          "field": "amount",
+                          "message": "Invalid Withdrawal Amount, it must be a positive integer"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Signature Generation failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Failed to generate signature. Please try again after 5 minutes. If any funds were deducted, don’t worry—they will be credited back within this time."
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "failed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Your signature request is still being processed. Please try again after 5 minute(s). If any funds were deducted, don’t worry—they will be credited back within this time."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/wallet/withdrawal/{id}": {
+      "put": {
+        "summary": "Update withdrawal status",
+        "description": "This API updates the status of the signature usage for a withdrawal request.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique identifier for the withdrawal request.",
+              "example": "a12345b6-78c9-0123-d456-789e012f34gh"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "description": "New status of the withdrawal request.",
+                    "example": "success"
+                  },
+                  "txhash": {
+                    "type": "string",
+                    "description": "(Optional) Transaction hash if available.",
+                    "example": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Withdrawal status updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Withdrawal status updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "status"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "status is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailure": {
+                    "summary": "Validation failure",
+                    "value": {
+                      "message": "Unable to get signature because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "Withdrawal Id",
+                          "message": "Invalid Withdrawal Id"
+                        },
+                        {
+                          "field": "Token ",
+                          "message": "Invalid token"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Withdrawal request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Withdrawal with request ID 123 not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Internal Server Error: Unable to update withdrawal status."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/wallet/owner": {
+      "get": {
+        "summary": "Retrieve wallet address update status for the authenticated user",
+        "description": "This API retrieves the wallet status of the authenticated user.\n- Checks if the wallet address has been updated.\n- Identifies if the user is the wallet owner.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User wallet status retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "User wallet status retrieved successfully"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "isWalletUpdated": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "isWalletOwner": {
+                          "type": "boolean",
+                          "example": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "User not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Update wallet address for authenticated user",
+        "description": "Updates the wallet address. Once updated, further updates are restricted.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Wallet"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "New wallet address for the user.",
+                    "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Wallet address updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Wallet address updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The provided details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "address"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "Address is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailure": {
+                    "summary": "Validation failure",
+                    "value": {
+                      "message": "Unable to update wallet address due to validation failures",
+                      "errors": [
+                        {
+                          "field": "address",
+                          "message": "Address is required"
+                        },
+                        {
+                          "field": "x-partner-code",
+                          "message": "Invalid partner code"
+                        },
+                        {
+                          "field": "x-app-code",
+                          "message": "Invalid app code"
+                        },
+                        {
+                          "field": "walletAddress",
+                          "message": "Wallet Address must be valid"
+                        }
+                      ]
+                    }
+                  },
+                  "walletAlreadyUpdated": {
+                    "summary": "Wallet Address Already Updated",
+                    "value": {
+                      "message": "Wallet Address already updated"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Internal Server Error: Unable to update wallet address."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/transaction": {
+      "get": {
+        "summary": "Get transactions",
+        "description": "This API returns transaction details. \n- Returns transaction details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Transactions"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort field",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "date",
+                "amount"
+              ]
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "description": "Sort direction",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Transaction type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "spend",
+                "deposit",
+                "refund"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Transaction status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "merchantName",
+            "in": "query",
+            "description": "Merchant name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "67a21ce9971b27fea38169e3"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "spend"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "completed"
+                          },
+                          "merchantName": {
+                            "type": "string",
+                            "example": "zomoto"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2025-02-04T04:59:17.272Z"
+                          },
+                          "amount": {
+                            "type": "number",
+                            "example": 100
+                          },
+                          "currency": {
+                            "type": "string",
+                            "example": "usd"
+                          },
+                          "localAmount": {
+                            "type": "number",
+                            "example": 100
+                          },
+                          "localCurrency": {
+                            "type": "string",
+                            "example": "usd"
+                          }
+                        }
+                      }
+                    },
+                    "totalTransactions": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "totalSpent": {
+                      "type": "number",
+                      "example": 100
+                    },
+                    "totalReceived": {
+                      "type": "number",
+                      "example": 0
+                    },
+                    "totalBalance": {
+                      "type": "number",
+                      "example": 0
+                    },
+                    "page": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "totalPages": {
+                      "type": "integer",
+                      "example": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/transaction/{id}": {
+      "get": {
+        "summary": "Get transaction detail",
+        "description": "Fetches details of a specific transaction.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Transactions"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier of the transaction.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "17389431-9fb7-4689-a15b-c799f5cacb63"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transaction fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Transaction fetched successfully."
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "173894319fb74689"
+                    },
+                    "from": {
+                      "type": "string",
+                      "example": "Abcd"
+                    },
+                    "card": {
+                      "type": "string",
+                      "example": "1234"
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "spend"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "completed"
+                    },
+                    "to": {
+                      "type": "string",
+                      "example": "test"
+                    },
+                    "date": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2024-12-14T04:54:57.326Z"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "example": 100
+                    },
+                    "currency": {
+                      "type": "string",
+                      "example": "usd"
+                    },
+                    "localAmount": {
+                      "type": "number",
+                      "example": 100
+                    },
+                    "localCurrency": {
+                      "type": "string",
+                      "example": "usd"
+                    },
+                    "transactionHash": {
+                      "type": "string",
+                      "example": "0x15189e46823bb"
+                    },
+                    "depositAddress": {
+                      "type": "string",
+                      "example": "0x15189e46823bb"
+                    },
+                    "chain": {
+                      "type": "string",
+                      "example": "Polygon (137)"
+                    }
+                  }
+                },
+                "examples": {
+                  "spendTransaction": {
+                    "summary": "Transaction Spent",
+                    "value": {
+                      "message": "Transaction fetched successfully.",
+                      "id": "173894319fb74689",
+                      "from": "Abcd",
+                      "card": "1234",
+                      "type": "spend",
+                      "status": "completed",
+                      "to": "test",
+                      "date": "2024-12-14T04:54:57.326Z",
+                      "amount": 100,
+                      "currency": "usd",
+                      "localAmount": 100,
+                      "localCurrency": "usd"
+                    }
+                  },
+                  "refundTransaction": {
+                    "summary": "Transaction Refund",
+                    "value": {
+                      "message": "Transaction fetched successfully.",
+                      "id": "173894319fb74689",
+                      "from": "test",
+                      "card": "1234",
+                      "type": "refund",
+                      "status": "completed",
+                      "to": "Abcd",
+                      "date": "2024-12-14T04:54:57.326Z",
+                      "amount": 100,
+                      "currency": "usd",
+                      "localAmount": 100,
+                      "localCurrency": "usd"
+                    }
+                  },
+                  "depositTransaction": {
+                    "summary": "Transaction Deposit",
+                    "value": {
+                      "message": "Transaction fetched successfully.",
+                      "id": "173894319fb74689",
+                      "from": "0x15189e46823bb",
+                      "to": "On-Chain",
+                      "type": "deposit",
+                      "depositAddress": "0x15189e46823bb",
+                      "chain": "Polygon (137)",
+                      "status": "completed",
+                      "date": "2024-12-14T04:54:57.326Z",
+                      "amount": 100,
+                      "currency": "usd",
+                      "transactionHash": "0x15189e46823bb"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Transaction detail not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Transaction detail not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/notification": {
+      "get": {
+        "summary": "Get notifications",
+        "description": "Retrieve the list of notifications for the user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "notifications": {
+                      "type": "array",
+                      "description": "List of user notifications",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "Your profile has been updated."
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-10-11T12:00:00Z"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while fetching notifications."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Unable to retrieve notifications"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Error occurred while fetching notifications.",
+                  "error": "Unable to retrieve notifications"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/notification/{id}": {
+      "put": {
+        "summary": "Update notification",
+        "description": "Update the read status of a notification.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the notification to update",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "read": {
+                    "type": "boolean",
+                    "description": "Whether the notification is read or not",
+                    "example": true
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Notification updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Notification updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Description of the error that occurred",
+                      "example": "Error occurred while fetching notifications."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error information (optional)",
+                      "example": "Unable to retrieve notifications"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Error occurred while updating notification.",
+                  "error": "Notification not found"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/account": {
+      "get": {
+        "summary": "Fetch Referral code and referral count",
+        "description": "Retreive referral code and number of reffered customers\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Account Summary"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account Information fetched Succesfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Referral Data retreived succesfully."
+                    },
+                    "badge": {
+                      "type": "object",
+                      "description": "Badge earned by the user based on their activities in the system.",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "description": "Short code for the badge.",
+                          "example": "SupF"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Full name of the badge.",
+                          "example": "SuperFan"
+                        }
+                      }
+                    },
+                    "referralCode": {
+                      "type": "string",
+                      "example": "absdkfjhika"
+                    },
+                    "referralDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 0.1
+                    },
+                    "referralDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "percentage",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "referralCount": {
+                      "type": "number",
+                      "example": 62
+                    },
+                    "referralEarning": {
+                      "type": "number",
+                      "example": 0
+                    },
+                    "referrerCode": {
+                      "type": "string",
+                      "example": "absdkfjhdsd"
+                    },
+                    "referrerDiscount": {
+                      "type": "number",
+                      "description": "Discount value for the referral.",
+                      "example": 0.2
+                    },
+                    "referrerDiscountType": {
+                      "type": "string",
+                      "description": "Type of discount applied",
+                      "example": "flat",
+                      "enum": [
+                        "percentage",
+                        "flat"
+                      ]
+                    },
+                    "totalEarning": {
+                      "type": "number",
+                      "example": 0
+                    },
+                    "totalClaimed": {
+                      "type": "number",
+                      "example": 0
+                    },
+                    "minClaimAmount": {
+                      "type": "number",
+                      "description": "In cents",
+                      "example": 50
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/account/reward/claim": {
+      "get": {
+        "summary": "Fetch all pending reward claim requests",
+        "description": "Retrieves all reward claim requests that are currently pending.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Account Summary"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved all pending reward claims.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "success"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Claims retrieved successfully"
+                    },
+                    "claims": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 123456789
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Claim status (pending, completed).",
+                            "example": "pending"
+                          },
+                          "amount": {
+                            "type": "number",
+                            "example": 211.45
+                          },
+                          "txhash": {
+                            "type": "string",
+                            "description": "Transaction hash of the completed claim request.",
+                            "example": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2025-02-04T04:59:17.272Z"
+                          }
+                        }
+                      }
+                    },
+                    "totalClaims": {
+                      "type": "number",
+                      "example": 100
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "example": 10
+                    },
+                    "page": {
+                      "type": "number",
+                      "example": 2
+                    },
+                    "limit": {
+                      "type": "number",
+                      "example": 10
+                    }
+                  }
+                },
+                "examples": {
+                  "PendingClaim": {
+                    "summary": "Example of a pending claim",
+                    "value": {
+                      "status": "success",
+                      "message": "Claims retrieved successfully",
+                      "claims": [
+                        {
+                          "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                          "status": "pending",
+                          "amount": 211.45,
+                          "txhash": "",
+                          "createdAt": "2025-02-27T11:50:40.000Z"
+                        }
+                      ],
+                      "totalClaims": 100,
+                      "totalPages": 10,
+                      "page": 2,
+                      "limit": 10
+                    }
+                  },
+                  "CompletedClaim": {
+                    "summary": "Example of a completed claim",
+                    "value": {
+                      "status": "success",
+                      "message": "Claims retrieved successfully",
+                      "claims": [
+                        {
+                          "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                          "status": "completed",
+                          "amount": 211.45,
+                          "txhash": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb",
+                          "createdAt": "2025-02-27T11:50:40.000Z"
+                        }
+                      ],
+                      "totalClaims": 100,
+                      "totalPages": 10,
+                      "page": 2,
+                      "limit": 10
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Raise a reward claim request",
+        "description": "Stores the data in the database indicating that the user's request for reward claim has been raised.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Account Summary"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request for reward claim has been raised successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "success"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Your reward claim request has been raised."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/app/version": {
+      "get": {
+        "summary": "Check App Version",
+        "description": "Endpoint to check if mobile app version requires update\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "App Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "currentVersion",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Current version of the mobile application",
+              "example": "1.2.3"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Version check completed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "latestVersion": {
+                      "type": "string",
+                      "description": "Latest available version of the app",
+                      "example": "2.0.0"
+                    },
+                    "forceUpdate": {
+                      "type": "boolean",
+                      "description": "Whether user must update before continuing",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Validation failed"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "missingVersion": {
+                    "summary": "Missing version",
+                    "value": {
+                      "message": "Current version is missing",
+                      "errors": [
+                        {
+                          "field": "currentVersion",
+                          "message": "Current version must be provided."
+                        }
+                      ]
+                    }
+                  },
+                  "invalidFormat": {
+                    "summary": "Invalid version format",
+                    "value": {
+                      "message": "Invalid version format",
+                      "errors": [
+                        {
+                          "field": "currentVersion",
+                          "message": "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
+                        }
+                      ]
+                    }
+                  },
+                  "futureVersion": {
+                    "summary": "Version cannot be greater than the latest version",
+                    "value": {
+                      "message": "Invalid version",
+                      "errors": [
+                        {
+                          "field": "currentVersion",
+                          "message": "Current version cannot be greater than the latest version."
+                        }
+                      ]
+                    }
+                  },
+                  "majorVersionMismatch": {
+                    "summary": "Multiple version updates pending",
+                    "value": {
+                      "message": "Multiple version updates required",
+                      "errors": [
+                        {
+                          "field": "currentVersion",
+                          "message": "Your app version (1.2.0) is more than one version behind the latest version."
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/app/consent": {
+      "get": {
+        "summary": "Retrieve the User Consent details",
+        "description": "This API returns the Consent information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "App Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Consent details fetched successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Response message",
+                      "example": "Consent Fetched Successfully"
+                    },
+                    "consent": {
+                      "type": "array",
+                      "description": "List of consents",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Unique identifier for the consent",
+                            "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "Type of consent (e.g., signup)",
+                            "example": "signup"
+                          },
+                          "accepted": {
+                            "type": "boolean",
+                            "description": "Whether the user accepted the consent",
+                            "example": false
+                          },
+                          "isMandatory": {
+                            "type": "boolean",
+                            "description": "Whether the consent is mandatory",
+                            "example": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Update the User Consent details",
+        "description": "This API Updates the Consent information of the user and returns the updated consent.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "App Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "List of consent acceptance details.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the consent",
+                      "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                    },
+                    "accepted": {
+                      "type": "boolean",
+                      "description": "Whether the user accepted the consent",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Consent Fetched Succesfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Consent Updated succesfully",
+                      "example": "Consent Updated succesfully"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The consent details are invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unable to save consent because of the validation failures"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "consent"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "Consent is required"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "validationFailureSample1": {
+                    "summary": "Missing consent",
+                    "value": {
+                      "message": "Unable to save card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "consent",
+                          "message": "Consent id required"
+                        }
+                      ]
+                    }
+                  },
+                  "validationFailureSample2": {
+                    "summary": "Invalid consent type",
+                    "value": {
+                      "message": "Unable to save card because of the validation failures",
+                      "errors": [
+                        {
+                          "field": "consentId",
+                          "message": "ConsentId should be of string type"
+                        },
+                        {
+                          "field": "accepted",
+                          "message": "accepted should be of boolean type"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/app/consent/status": {
+      "get": {
+        "summary": "Retrieve the User Consent Status",
+        "description": "This API returns the Consent Status information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "App Management"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Consent Status Fetched Succesfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Consent fetched succesfully",
+                      "example": "Consent Status fetched succesfully"
+                    },
+                    "consentStatus": {
+                      "type": "boolean",
+                      "description": "The consent status",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/log": {
+      "post": {
+        "summary": "Submit Logs",
+        "description": "Endpoint to submit logs from a mobile device\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+        "tags": [
+          "Log"
+        ],
+        "parameters": [
+          {
+            "name": "x-partner-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Partner code of this user.",
+              "example": "AB89DE4F"
+            }
+          },
+          {
+            "name": "x-app-code",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Application code used for validating mobile-based requests.",
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Detailed log message describing the event or error.",
+                    "example": "An error occurred while processing the request."
+                  },
+                  "logLevel": {
+                    "type": "string",
+                    "description": "Severity level of the log. Common levels include INFO, WARN, ERROR, DEBUG.",
+                    "example": "ERROR",
+                    "enum": [
+                      "INFO",
+                      "WARN",
+                      "ERROR",
+                      "DEBUG"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Specific type or category of the log. Examples include RuntimeError, ValidationError, NetworkError.",
+                    "example": "RuntimeError",
+                    "enum": [
+                      "RuntimeError",
+                      "ValidationError",
+                      "NetworkError"
+                    ]
+                  },
+                  "stack": {
+                    "type": "string",
+                    "description": "Stack trace of the error, providing detailed information about where the error occurred.",
+                    "example": "Error: An error occurred at ..."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "URL of the request that generated the log. This can be any component URL if the logging comes from a mobile device.",
+                    "example": "https://api.example.com/resource"
+                  },
+                  "deviceDetail": {
+                    "type": "object",
+                    "properties": {
+                      "sysName": {
+                        "type": "string",
+                        "description": "The name of the operating system on the device.",
+                        "example": "android"
+                      },
+                      "sysVersion": {
+                        "type": "string",
+                        "description": "The version of the operating system on the device.",
+                        "example": "14"
+                      }
+                    },
+                    "required": [
+                      "sysName",
+                      "sysVersion"
+                    ]
+                  }
+                },
+                "required": [
+                  "message",
+                  "logLevel",
+                  "stack",
+                  "url",
+                  "sysName",
+                  "sysVersion"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Log submitted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Log submitted successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid request payload."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "example": "logLevel"
+                          },
+                          "message": {
+                            "type": "string",
+                            "example": "logLevel is required."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is denied due to invalid or missing token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized access. Token is missing or invalid."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid or expired token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred on the server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Something went wrong on the server. Please try again later."
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal Server Error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SignInEmailRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The user's email address",
+            "example": "user@example.com"
+          },
+          "password": {
+            "type": "string",
+            "description": "The user's password",
+            "example": "password123"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ]
+      },
+      "SignInResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Successfully authenticated."
+          },
+          "accessToken": {
+            "type": "string",
+            "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "Long-lived refresh token (used to refresh the access token)",
+            "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+          },
+          "token2fa": {
+            "type": "string",
+            "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+            "example": "U2FsdGVkX1...",
+            "nullable": true
+          }
+        }
+      },
+      "SignInSocialResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Successfully authenticated."
+          },
+          "accessToken": {
+            "type": "string",
+            "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "Long-lived refresh token (used to refresh the access token)",
+            "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+          },
+          "token2fa": {
+            "type": "string",
+            "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+            "example": "U2FsdGVkX1...",
+            "nullable": true
+          }
+        }
+      },
+      "SignInEmailErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Invalid credentials"
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "Authentication failed"
+          }
+        }
+      },
+      "SignInSocialRequest": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "The social provider used for signing in (e.g., google, facebook)",
+            "example": "google"
+          },
+          "token": {
+            "type": "string",
+            "description": "The OAuth token from the social provider",
+            "example": "eyJhbGciOiJIUzI1..."
+          }
+        },
+        "required": [
+          "provider",
+          "token"
+        ]
+      },
+      "SignInSocialErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Invalid social token"
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "Authentication failed"
+          }
+        }
+      },
+      "SignOutErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Error occurred while signing out"
+          }
+        }
+      },
+      "SignInMobileRequest": {
+        "type": "object",
+        "properties": {
+          "authToken": {
+            "type": "string",
+            "description": "The permanent mobile verification code issued after successful mobile verification via the **verify-otp** API.",
+            "example": "eyJhbGciOiJIUzI1..."
+          }
+        },
+        "required": [
+          "authToken"
+        ]
+      },
+      "SignInMobileErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Invalid verification code"
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "Authentication failed"
+          }
+        }
+      },
+      "SignUpEmailRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The user's email address",
+            "example": "user@example.com"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The user's first name",
+            "example": "John"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The user's last name",
+            "example": "Doe"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "SignUpEmailResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message for the user",
+            "example": "User registered successfully. Please verify your email."
+          }
+        }
+      },
+      "SignUpEmailErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error",
+            "example": "A descriptive error message"
+          },
+          "error": {
+            "type": "string",
+            "description": "Optional detailed error information (only for server errors)",
+            "example": "Detailed error information"
+          }
+        }
+      },
+      "VerifyEmailResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Success message indicating the email has been verified.",
+            "example": "Email verified successfully. Please create your password."
+          },
+          "accessToken": {
+            "type": "string",
+            "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "Long-lived refresh token (used to refresh the access token)",
+            "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+          }
+        }
+      },
+      "VerifyEmailErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Error message if the token is invalid or expired",
+            "example": "Invalid or expired token"
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information",
+            "example": "Verification failed"
+          }
+        }
+      },
+      "RefreshTokenRequest": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "description": "The refresh token provided during sign-in *",
+            "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+          }
+        },
+        "required": [
+          "refreshToken"
+        ]
+      },
+      "RefreshTokenResponse": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "(Optional) A new refresh token, if a new one is issued",
+            "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+          }
+        }
+      },
+      "RefreshTokenErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Invalid refresh token"
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information",
+            "example": "Refresh token expired or invalid"
+          }
+        }
+      },
+      "CaptchaInitResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Captcha challenge initialized successfully."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "lot_number": {
+                "type": "string",
+                "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+              },
+              "captcha_type": {
+                "type": "string",
+                "example": "slide"
+              },
+              "captcha_output": {
+                "type": "string",
+                "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+              },
+              "pass_token": {
+                "type": "string",
+                "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+              },
+              "captcha_id": {
+                "type": "string",
+                "example": "fb362ff464a632747b0dd0ea90bab013"
+              }
+            }
+          }
+        }
+      },
+      "CaptchaValidationRequest": {
+        "type": "object",
+        "properties": {
+          "mobile": {
+            "type": "string",
+            "example": "9456262167"
+          },
+          "captcha_id": {
+            "type": "string",
+            "example": "d81db9ghjk82bc8abb8b93a6b24b"
+          },
+          "lot_number": {
+            "type": "string",
+            "example": "362ff4642747b0dd0ea90bab013ss"
+          },
+          "captcha_output": {
+            "type": "string",
+            "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+          },
+          "pass_token": {
+            "type": "string",
+            "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+          },
+          "gen_time": {
+            "type": "string",
+            "example": "1747751473"
+          }
+        },
+        "required": [
+          "mobile",
+          "captcha_id",
+          "lot_number",
+          "captcha_output",
+          "pass_token",
+          "gen_time"
+        ]
+      },
+      "CaptchaValidationResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Captcha validated successfully."
+          },
+          "accessToken": {
+            "type": "string",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+          }
+        }
+      },
+      "CaptchaValidationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Captcha validation failed."
+          },
+          "error": {
+            "type": "string",
+            "example": "pass_token expire"
+          }
+        }
+      },
+      "Generate2FASecretResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Success message",
+            "example": "2FA secret generated successfully."
+          },
+          "qrCodeData": {
+            "type": "string",
+            "description": "QR code image data for scanning",
+            "example": "data:image/png;base64,iVBORw0..."
+          },
+          "secret": {
+            "type": "string",
+            "description": "The secret, in case user wants to manually enter it",
+            "example": "JBSWY3DPEHPK3PXP"
+          }
+        }
+      },
+      "Enable2FARequest": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "token generated by the user's authenticator app",
+            "example": 123456
+          }
+        },
+        "required": [
+          "token"
+        ]
+      },
+      "Enable2FAResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message for the user",
+            "example": "Two-factor authentication enabled successfully."
+          }
+        }
+      },
+      "Enable2FAErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Error occurred while enabling two-factor authentication."
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if OTP verification fails",
+            "example": "Invalid OTP. Please try again."
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Auto-generated UUID for the document",
+            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The person's first name",
+            "maxLength": 50
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The person's last name",
+            "maxLength": 50
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "description": "The person's birth date"
+          },
+          "nationalId": {
+            "type": "string",
+            "description": "National ID (9-digit SSN for US users)"
+          },
+          "countryOfIssue": {
+            "type": "string",
+            "description": "2-letter country code where the ID was issued",
+            "maxLength": 2
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The person's email address"
+          },
+          "address": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "line1": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "line2": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "city": {
+                    "type": "string",
+                    "maxLength": 50
+                  },
+                  "region": {
+                    "type": "string",
+                    "maxLength": 60
+                  },
+                  "postalCode": {
+                    "type": "string",
+                    "maxLength": 15
+                  },
+                  "countryCode": {
+                    "type": "string",
+                    "maxLength": 2
+                  },
+                  "country": {
+                    "type": "string",
+                    "maxLength": 50
+                  }
+                },
+                "required": [
+                  "line1",
+                  "city",
+                  "region",
+                  "postalCode",
+                  "countryCode",
+                  "country"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "The person's address"
+              }
+            ]
+          }
+        },
+        "required": [
+          "firstName",
+          "lastName",
+          "birthDate",
+          "nationalId",
+          "countryOfIssue",
+          "email",
+          "address"
+        ]
+      },
+      "Document": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Auto-generated UUID for the document",
+            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the document",
+            "example": "passport_image.png"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+            "example": "CERT_INC"
+          },
+          "side": {
+            "type": "string",
+            "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+            "example": "front, back"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+            "example": "USA",
+            "maxLength": 3
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "InitialUser": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "firstName": {
+                "type": "string",
+                "description": "The person's first name",
+                "maxLength": 50
+              },
+              "lastName": {
+                "type": "string",
+                "description": "The person's last name",
+                "maxLength": 50
+              },
+              "birthDate": {
+                "type": "string",
+                "format": "date",
+                "description": "The person's birth date"
+              },
+              "nationalId": {
+                "type": "string",
+                "description": "National ID (9-digit SSN for US users)"
+              },
+              "countryOfIssue": {
+                "type": "string",
+                "description": "2-letter country code where the ID was issued",
+                "maxLength": 2
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "description": "The person's email address"
+              },
+              "address": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "line1": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "line2": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "city": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "region": {
+                        "type": "string",
+                        "maxLength": 60
+                      },
+                      "postalCode": {
+                        "type": "string",
+                        "maxLength": 15
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "maxLength": 2
+                      },
+                      "country": {
+                        "type": "string",
+                        "maxLength": 50
+                      }
+                    },
+                    "required": [
+                      "line1",
+                      "city",
+                      "region",
+                      "postalCode",
+                      "countryCode",
+                      "country"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "description": "The person's address"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "firstName",
+              "lastName",
+              "birthDate",
+              "nationalId",
+              "countryOfIssue",
+              "email",
+              "address"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "The initial user of the company",
+            "properties": {
+              "role": {
+                "type": "string",
+                "description": "This user's role at their company"
+              },
+              "walletAddress": {
+                "type": "string",
+                "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+              },
+              "ipAddress": {
+                "type": "string",
+                "description": "The user's IP address"
+              },
+              "iovationBlackbox": {
+                "type": "string",
+                "description": "A blackbox string generated by the client side Iovation library"
+              }
+            },
+            "required": [
+              "iovationBlackbox",
+              "ipAddress",
+              "isTermsOfServiceAccepted"
+            ]
+          }
+        ]
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Auto-generated UUID for the document",
+            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+          },
+          "line1": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "line2": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "city": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "region": {
+            "type": "string",
+            "maxLength": 60
+          },
+          "postalCode": {
+            "type": "string",
+            "maxLength": 15
+          },
+          "countryCode": {
+            "type": "string",
+            "maxLength": 2
+          },
+          "country": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": [
+          "line1",
+          "city",
+          "region",
+          "postalCode",
+          "countryCode",
+          "country"
+        ]
+      },
+      "Entity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Auto-generated UUID for the document",
+            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+          },
+          "name": {
+            "type": "string",
+            "description": "The legal entity's name"
+          },
+          "type": {
+            "type": "string",
+            "description": "The legal entity's type - LLC, S Corp, etc."
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the legal entity, and its activities"
+          },
+          "taxId": {
+            "type": "string",
+            "description": "The legal entity's national tax id"
+          },
+          "registrationNumber": {
+            "type": "string",
+            "description": "The legal entity's registration number"
+          },
+          "website": {
+            "type": "string",
+            "description": "The legal entity's website"
+          },
+          "expectedSpend": {
+            "type": "string",
+            "description": "How much the legal entity expects to spend each month"
+          },
+          "industry": {
+            "type": "string",
+            "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+          }
+        },
+        "required": [
+          "name",
+          "taxId",
+          "registrationNumber",
+          "website"
+        ]
+      },
+      "UserAddress": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "line1": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "line2": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "maxLength": 50
+              },
+              "region": {
+                "type": "string",
+                "maxLength": 60
+              },
+              "postalCode": {
+                "type": "string",
+                "maxLength": 15
+              },
+              "countryCode": {
+                "type": "string",
+                "maxLength": 2
+              },
+              "country": {
+                "type": "string",
+                "maxLength": 50
+              }
+            },
+            "required": [
+              "line1",
+              "city",
+              "region",
+              "postalCode",
+              "countryCode",
+              "country"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "The person's address"
+          }
+        ]
+      },
+      "BusinessAddress": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "line1": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "line2": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "maxLength": 50
+              },
+              "region": {
+                "type": "string",
+                "maxLength": 60
+              },
+              "postalCode": {
+                "type": "string",
+                "maxLength": 15
+              },
+              "countryCode": {
+                "type": "string",
+                "maxLength": 2
+              },
+              "country": {
+                "type": "string",
+                "maxLength": 50
+              }
+            },
+            "required": [
+              "line1",
+              "city",
+              "region",
+              "postalCode",
+              "countryCode",
+              "country"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "The company's physical address"
+          }
+        ]
+      },
+      "ProfileUser": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "firstName": {
+                "type": "string",
+                "description": "The person's first name",
+                "maxLength": 50
+              },
+              "lastName": {
+                "type": "string",
+                "description": "The person's last name",
+                "maxLength": 50
+              },
+              "birthDate": {
+                "type": "string",
+                "format": "date",
+                "description": "The person's birth date"
+              },
+              "nationalId": {
+                "type": "string",
+                "description": "National ID (9-digit SSN for US users)"
+              },
+              "countryOfIssue": {
+                "type": "string",
+                "description": "2-letter country code where the ID was issued",
+                "maxLength": 2
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "description": "The person's email address"
+              },
+              "address": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "line1": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "line2": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "city": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "region": {
+                        "type": "string",
+                        "maxLength": 60
+                      },
+                      "postalCode": {
+                        "type": "string",
+                        "maxLength": 15
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "maxLength": 2
+                      },
+                      "country": {
+                        "type": "string",
+                        "maxLength": 50
+                      }
+                    },
+                    "required": [
+                      "line1",
+                      "city",
+                      "region",
+                      "postalCode",
+                      "countryCode",
+                      "country"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "description": "The person's address"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "firstName",
+              "lastName",
+              "birthDate",
+              "nationalId",
+              "countryOfIssue",
+              "email",
+              "address"
+            ]
+          },
+          {
+            "type": "object",
+            "description": "This is the profile of the user"
+          }
+        ]
+      },
+      "ProfileCompany": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "This is the profile of the company",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "name": {
+                "type": "string",
+                "description": "The legal entity's name"
+              },
+              "type": {
+                "type": "string",
+                "description": "The legal entity's type - LLC, S Corp, etc."
+              },
+              "description": {
+                "type": "string",
+                "description": "A brief description of the legal entity, and its activities"
+              },
+              "taxId": {
+                "type": "string",
+                "description": "The legal entity's national tax id"
+              },
+              "registrationNumber": {
+                "type": "string",
+                "description": "The legal entity's registration number"
+              },
+              "website": {
+                "type": "string",
+                "description": "The legal entity's website"
+              },
+              "expectedSpend": {
+                "type": "string",
+                "description": "How much the legal entity expects to spend each month"
+              },
+              "industry": {
+                "type": "string",
+                "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+              }
+            },
+            "required": [
+              "name",
+              "taxId",
+              "registrationNumber",
+              "website"
+            ]
+          }
+        ]
+      },
+      "Profile": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "allOf": [
+              {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The person's first name",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The person's last name",
+                        "maxLength": 50
+                      },
+                      "birthDate": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "The person's birth date"
+                      },
+                      "nationalId": {
+                        "type": "string",
+                        "description": "National ID (9-digit SSN for US users)"
+                      },
+                      "countryOfIssue": {
+                        "type": "string",
+                        "description": "2-letter country code where the ID was issued",
+                        "maxLength": 2
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The person's email address"
+                      },
+                      "address": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "line2": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "city": {
+                                "type": "string",
+                                "maxLength": 50
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 60
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "maxLength": 15
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "maxLength": 2
+                              },
+                              "country": {
+                                "type": "string",
+                                "maxLength": 50
+                              }
+                            },
+                            "required": [
+                              "line1",
+                              "city",
+                              "region",
+                              "postalCode",
+                              "countryCode",
+                              "country"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "description": "The person's address"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName",
+                      "birthDate",
+                      "nationalId",
+                      "countryOfIssue",
+                      "email",
+                      "address"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "description": "This is the profile of the user"
+                  }
+                ]
+              }
+            ]
+          },
+          "company": {
+            "allOf": [
+              {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "description": "This is the profile of the company",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "The legal entity's name"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "The legal entity's type - LLC, S Corp, etc."
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "A brief description of the legal entity, and its activities"
+                      },
+                      "taxId": {
+                        "type": "string",
+                        "description": "The legal entity's national tax id"
+                      },
+                      "registrationNumber": {
+                        "type": "string",
+                        "description": "The legal entity's registration number"
+                      },
+                      "website": {
+                        "type": "string",
+                        "description": "The legal entity's website"
+                      },
+                      "expectedSpend": {
+                        "type": "string",
+                        "description": "How much the legal entity expects to spend each month"
+                      },
+                      "industry": {
+                        "type": "string",
+                        "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "taxId",
+                      "registrationNumber",
+                      "website"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "user",
+          "company"
+        ]
+      },
+      "GetProfileResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Profile retrieved successfully."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique ID of the KYB draft.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the company.",
+            "example": "Acme Corp"
+          },
+          "address": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "line1": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "line2": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "city": {
+                    "type": "string",
+                    "maxLength": 50
+                  },
+                  "region": {
+                    "type": "string",
+                    "maxLength": 60
+                  },
+                  "postalCode": {
+                    "type": "string",
+                    "maxLength": 15
+                  },
+                  "countryCode": {
+                    "type": "string",
+                    "maxLength": 2
+                  },
+                  "country": {
+                    "type": "string",
+                    "maxLength": 50
+                  }
+                },
+                "required": [
+                  "line1",
+                  "city",
+                  "region",
+                  "postalCode",
+                  "countryCode",
+                  "country"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "The company's physical address"
+              }
+            ]
+          },
+          "company": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "name": {
+                "type": "string",
+                "description": "The legal entity's name"
+              },
+              "type": {
+                "type": "string",
+                "description": "The legal entity's type - LLC, S Corp, etc."
+              },
+              "description": {
+                "type": "string",
+                "description": "A brief description of the legal entity, and its activities"
+              },
+              "taxId": {
+                "type": "string",
+                "description": "The legal entity's national tax id"
+              },
+              "registrationNumber": {
+                "type": "string",
+                "description": "The legal entity's registration number"
+              },
+              "website": {
+                "type": "string",
+                "description": "The legal entity's website"
+              },
+              "expectedSpend": {
+                "type": "string",
+                "description": "How much the legal entity expects to spend each month"
+              },
+              "industry": {
+                "type": "string",
+                "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+              }
+            },
+            "required": [
+              "name",
+              "taxId",
+              "registrationNumber",
+              "website"
+            ]
+          },
+          "documents": {
+            "type": "array",
+            "description": "List of KYB documents.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the document",
+                  "example": "passport_image.png"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                  "example": "CERT_INC"
+                },
+                "side": {
+                  "type": "string",
+                  "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                  "example": "front, back"
+                },
+                "country": {
+                  "type": "string",
+                  "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                  "example": "USA",
+                  "maxLength": 3
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
+          "representatives": {
+            "type": "array",
+            "description": "List of company representatives.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "The current status of the KYB process.",
+            "example": "Pending"
+          },
+          "ultimateBeneficialOwners": {
+            "type": "array",
+            "description": "List of the company's ultimate beneficial owners.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            }
+          }
+        }
+      },
+      "GetProfileErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A general error message for the failed profile retrieval.",
+            "example": "Error occurred while retrieving the profile."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information to assist in troubleshooting.",
+            "example": "Profile not found."
+          }
+        }
+      },
+      "UpdateProfileRequest": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "This is the profile of the user"
+              }
+            ]
+          },
+          "company": {
+            "allOf": [
+              {
+                "type": "object",
+                "description": "This is the profile of the company",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The legal entity's name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The legal entity's type - LLC, S Corp, etc."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A brief description of the legal entity, and its activities"
+                  },
+                  "taxId": {
+                    "type": "string",
+                    "description": "The legal entity's national tax id"
+                  },
+                  "registrationNumber": {
+                    "type": "string",
+                    "description": "The legal entity's registration number"
+                  },
+                  "website": {
+                    "type": "string",
+                    "description": "The legal entity's website"
+                  },
+                  "expectedSpend": {
+                    "type": "string",
+                    "description": "How much the legal entity expects to spend each month"
+                  },
+                  "industry": {
+                    "type": "string",
+                    "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                  }
+                },
+                "required": [
+                  "name",
+                  "taxId",
+                  "registrationNumber",
+                  "website"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "UpdateProfileResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Profile updated successfully."
+          },
+          "profile": {
+            "type": "object",
+            "properties": {
+              "user": {
+                "allOf": [
+                  {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "This is the profile of the user"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "company": {
+                "allOf": [
+                  {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "description": "This is the profile of the company",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The legal entity's name"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The legal entity's type - LLC, S Corp, etc."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "A brief description of the legal entity, and its activities"
+                          },
+                          "taxId": {
+                            "type": "string",
+                            "description": "The legal entity's national tax id"
+                          },
+                          "registrationNumber": {
+                            "type": "string",
+                            "description": "The legal entity's registration number"
+                          },
+                          "website": {
+                            "type": "string",
+                            "description": "The legal entity's website"
+                          },
+                          "expectedSpend": {
+                            "type": "string",
+                            "description": "How much the legal entity expects to spend each month"
+                          },
+                          "industry": {
+                            "type": "string",
+                            "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "taxId",
+                          "registrationNumber",
+                          "website"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "user",
+              "company"
+            ]
+          }
+        }
+      },
+      "ProfileErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Error occurred while processing the profile request."
+          },
+          "error": {
+            "type": "string",
+            "example": "Invalid input or data not found."
+          }
+        }
+      },
+      "KYBFormRequest": {
+        "type": "object",
+        "properties": {
+          "initialUser": {
+            "type": "object",
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "The initial user of the company",
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "description": "This user's role at their company"
+                  },
+                  "walletAddress": {
+                    "type": "string",
+                    "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                  },
+                  "ipAddress": {
+                    "type": "string",
+                    "description": "The user's IP address"
+                  },
+                  "iovationBlackbox": {
+                    "type": "string",
+                    "description": "A blackbox string generated by the client side Iovation library"
+                  }
+                },
+                "required": [
+                  "iovationBlackbox",
+                  "ipAddress",
+                  "isTermsOfServiceAccepted"
+                ]
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the company looking to create an account"
+          },
+          "address": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "line1": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "line2": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "city": {
+                    "type": "string",
+                    "maxLength": 50
+                  },
+                  "region": {
+                    "type": "string",
+                    "maxLength": 60
+                  },
+                  "postalCode": {
+                    "type": "string",
+                    "maxLength": 15
+                  },
+                  "countryCode": {
+                    "type": "string",
+                    "maxLength": 2
+                  },
+                  "country": {
+                    "type": "string",
+                    "maxLength": 50
+                  }
+                },
+                "required": [
+                  "line1",
+                  "city",
+                  "region",
+                  "postalCode",
+                  "countryCode",
+                  "country"
+                ]
+              },
+              {
+                "type": "object",
+                "description": "The company's physical address"
+              }
+            ]
+          },
+          "chainId": {
+            "type": "string",
+            "description": "the chain id of the company's external collateral contract"
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "the address of the company's external collateral contract;"
+          },
+          "entity": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Auto-generated UUID for the document",
+                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+              },
+              "name": {
+                "type": "string",
+                "description": "The legal entity's name"
+              },
+              "type": {
+                "type": "string",
+                "description": "The legal entity's type - LLC, S Corp, etc."
+              },
+              "description": {
+                "type": "string",
+                "description": "A brief description of the legal entity, and its activities"
+              },
+              "taxId": {
+                "type": "string",
+                "description": "The legal entity's national tax id"
+              },
+              "registrationNumber": {
+                "type": "string",
+                "description": "The legal entity's registration number"
+              },
+              "website": {
+                "type": "string",
+                "description": "The legal entity's website"
+              },
+              "expectedSpend": {
+                "type": "string",
+                "description": "How much the legal entity expects to spend each month"
+              },
+              "industry": {
+                "type": "string",
+                "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+              }
+            },
+            "required": [
+              "name",
+              "taxId",
+              "registrationNumber",
+              "website"
+            ]
+          },
+          "representatives": {
+            "type": "array",
+            "description": "The company's representatives",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            }
+          },
+          "ultimateBeneficialOwners": {
+            "type": "array",
+            "description": "The company's ultimate beneficial owners",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            }
+          }
+        },
+        "required": [
+          "initialUser",
+          "name",
+          "address",
+          "entity",
+          "representatives",
+          "ultimateBeneficialOwners"
+        ]
+      },
+      "KYBFormResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Indicates the form is in draft mode.",
+            "example": "Pending",
+            "enum": [
+              "PENDING"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Message providing more information about the draft status.",
+            "example": "KYB information saved successfully."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique ID for tracking the draft submission.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp of the last update.",
+            "example": "2024-10-14T12:34:56Z"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The form field with the issue.",
+            "example": "businessName"
+          },
+          "message": {
+            "type": "string",
+            "description": "Description of the validation error.",
+            "example": "The business name is required."
+          }
+        }
+      },
+      "FormErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "General message about the validation error.",
+            "example": "Validation Failed"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "description": "The form field with the issue.",
+                  "example": "businessName"
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Description of the validation error.",
+                  "example": "The business name is required."
+                }
+              }
+            }
+          }
+        }
+      },
+      "GetKYBResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A success message for the response.",
+            "example": "KYB information retrieved successfully."
+          },
+          "kybData": {
+            "type": "object",
+            "description": "The KYB information retrieved for the company.",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The unique ID of the KYB draft.",
+                "example": "550e8400-e29b-41d4-a716-446655440000"
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the company.",
+                "example": "Acme Corp"
+              },
+              "address": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "line1": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "line2": {
+                        "type": "string",
+                        "maxLength": 100
+                      },
+                      "city": {
+                        "type": "string",
+                        "maxLength": 50
+                      },
+                      "region": {
+                        "type": "string",
+                        "maxLength": 60
+                      },
+                      "postalCode": {
+                        "type": "string",
+                        "maxLength": 15
+                      },
+                      "countryCode": {
+                        "type": "string",
+                        "maxLength": 2
+                      },
+                      "country": {
+                        "type": "string",
+                        "maxLength": 50
+                      }
+                    },
+                    "required": [
+                      "line1",
+                      "city",
+                      "region",
+                      "postalCode",
+                      "countryCode",
+                      "country"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "description": "The company's physical address"
+                  }
+                ]
+              },
+              "chainId": {
+                "type": "string",
+                "description": "the chain id of the company's external collateral contract"
+              },
+              "documents": {
+                "type": "array",
+                "description": "List of KYB documents.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the document",
+                      "example": "passport_image.png"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                      "example": "CERT_INC"
+                    },
+                    "side": {
+                      "type": "string",
+                      "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                      "example": "front, back"
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                      "example": "USA",
+                      "maxLength": 3
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              },
+              "entity": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The legal entity's name"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The legal entity's type - LLC, S Corp, etc."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A brief description of the legal entity, and its activities"
+                  },
+                  "taxId": {
+                    "type": "string",
+                    "description": "The legal entity's national tax id"
+                  },
+                  "registrationNumber": {
+                    "type": "string",
+                    "description": "The legal entity's registration number"
+                  },
+                  "website": {
+                    "type": "string",
+                    "description": "The legal entity's website"
+                  },
+                  "expectedSpend": {
+                    "type": "string",
+                    "description": "How much the legal entity expects to spend each month"
+                  },
+                  "industry": {
+                    "type": "string",
+                    "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                  }
+                },
+                "required": [
+                  "name",
+                  "taxId",
+                  "registrationNumber",
+                  "website"
+                ]
+              },
+              "representatives": {
+                "type": "array",
+                "description": "List of company representatives.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                }
+              },
+              "ultimateBeneficialOwners": {
+                "type": "array",
+                "description": "List of the company's ultimate beneficial owners.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                }
+              },
+              "status": {
+                "type": "string",
+                "description": "The current status of the KYB process.",
+                "example": "Pending"
+              },
+              "referralCode": {
+                "type": "string",
+                "example": "ABCD1234"
+              },
+              "referralCount": {
+                "type": "number",
+                "example": 10
+              }
+            }
+          }
+        }
+      },
+      "GetKYBErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A general error message.",
+            "example": "Error occurred while retrieving KYB information."
+          },
+          "error": {
+            "type": "string",
+            "description": "A detailed error message for troubleshooting.",
+            "example": "KYB record not found."
+          }
+        }
+      },
+      "KYBStatusResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "pending",
+            "enum": [
+              "notStarted",
+              "pending",
+              "pendingEmailVerification",
+              "emailVerified",
+              "saved",
+              "needsVerification",
+              "verificationPending",
+              "underReview",
+              "manualReview",
+              "needsInformation",
+              "verified",
+              "rejected",
+              "cancelled",
+              "denied",
+              "locked"
+            ]
+          }
+        }
+      },
+      "KYBStatusErrorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "MISSING_INFORMATION"
+          },
+          "message": {
+            "type": "string",
+            "example": "Additional business details required."
+          }
+        }
+      },
+      "KYBSubmitResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message providing more information about the submission.",
+            "example": "KYB form submitted successfully."
+          }
+        }
+      },
+      "IndividualUserAddress": {
+        "type": "object",
+        "properties": {
+          "line1": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "city": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "countryCode": {
+            "type": "string",
+            "maxLength": 2
+          },
+          "country": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": [
+          "line1",
+          "city",
+          "countryCode",
+          "country"
+        ]
+      },
+      "IndividualUserRequest": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "The customer's first name",
+            "example": "John",
+            "maxLength": 50
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The customer's last name",
+            "example": "Doe",
+            "maxLength": 50
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The customer's email address",
+            "example": "john.doe@example.com"
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "description": "The person's birth date"
+          },
+          "address": {
+            "type": "object",
+            "properties": {
+              "line1": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "maxLength": 50
+              },
+              "countryCode": {
+                "type": "string",
+                "maxLength": 2
+              },
+              "country": {
+                "type": "string",
+                "maxLength": 50
+              }
+            },
+            "required": [
+              "line1",
+              "city",
+              "countryCode",
+              "country"
+            ]
+          },
+          "phoneCountryCode": {
+            "type": "string",
+            "description": "Customer country code",
+            "example": 91,
+            "maxLength": 3
+          },
+          "phoneNumber": {
+            "type": "string",
+            "description": "phoneNumber",
+            "example": 9999999999,
+            "maxLength": 15
+          },
+          "occupation": {
+            "type": "string",
+            "description": "occupation code fetched from master api",
+            "example": "11-3011",
+            "maxLength": 50
+          },
+          "annualSalary": {
+            "type": "number",
+            "description": "annualSalary",
+            "example": 4000000
+          },
+          "accountPurpose": {
+            "type": "string",
+            "description": "accountPurpose",
+            "example": "Investment",
+            "maxLength": 15
+          },
+          "expectedMonthlySpend": {
+            "type": "number",
+            "description": "expectedMonthlySpend",
+            "example": 10000
+          },
+          "walletAddress": {
+            "type": "string",
+            "description": "The person's wallet address; required if using the hosted completion flow and a non-custodial solution, but not required otherwise",
+            "example": "0x1234...abcd"
+          },
+          "isTermOfServiceAccepted": {
+            "type": "boolean",
+            "description": "is customer accepted all terms of service",
+            "example": true
+          },
+          "isWalletOwner": {
+            "type": "boolean",
+            "description": "is customer owner of wallet address",
+            "example": true
+          }
+        },
+        "required": [
+          "firstName",
+          "lastName",
+          "birthDate",
+          "walletAddress",
+          "address",
+          "ipAddress",
+          "isTermOfServiceAccepted"
+        ]
+      },
+      "KYCFormResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Indicates the form is in draft mode.",
+            "example": "Pending",
+            "enum": [
+              "PENDING"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Message providing more information about the draft status.",
+            "example": "KYC application initiated successfully."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique ID for tracking the draft submission.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp of the last update.",
+            "example": "2024-10-14T12:34:56Z"
+          },
+          "nextSteps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "verificationLink": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "example": "https://app-kyc.xyz/kyc"
+                    },
+                    "params": {
+                      "type": "object",
+                      "properties": {
+                        "userId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                        },
+                        "redirect": {
+                          "type": "string",
+                          "format": "url",
+                          "example": "https://app-qa.pay.com/kycConfirmation"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "KYCErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Error message indicating the reason for failure",
+            "example": "Unable to initiate KYC because of the validation failures"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "description": "The field that caused the validation error",
+                  "example": "walletAddress"
+                },
+                "message": {
+                  "type": "string",
+                  "description": "The validation error message",
+                  "example": "walletAddress must be a valid address"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GetKYCResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A success message for the response.",
+            "example": "KYC information retrieved successfully."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique ID of the KYC draft.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the individual user.",
+            "example": "John",
+            "maxLength": 50
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the individual user.",
+            "example": "Doe",
+            "maxLength": 50
+          },
+          "createdOn": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the user registers in the system.",
+            "example": "2024-10-14T12:34:56Z"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The email address of the individual user.",
+            "example": "johndoe@johndoe.com"
+          },
+          "address": {
+            "type": "object",
+            "properties": {
+              "line1": {
+                "type": "string",
+                "description": "The first line of the address.",
+                "example": "123, ABC Street",
+                "maxLength": 100
+              },
+              "city": {
+                "type": "string",
+                "description": "The city of the address.",
+                "example": "XYZ",
+                "maxLength": 50
+              },
+              "countryCode": {
+                "type": "string",
+                "description": "The country code of the address.",
+                "example": "IN",
+                "maxLength": 2,
+                "minLength": 2
+              },
+              "country": {
+                "type": "string",
+                "description": "The country of the address.",
+                "example": "India",
+                "maxLength": 50
+              }
+            }
+          },
+          "phoneCountryCode": {
+            "type": "string",
+            "description": "The country code of the phone number.",
+            "example": "91",
+            "maxLength": 3
+          },
+          "phoneNumber": {
+            "type": "string",
+            "description": "The phone number of the individual user.",
+            "example": "1234567890",
+            "maxLength": 15,
+            "minLength": 1
+          },
+          "badge": {
+            "type": "object",
+            "description": "Badge earned by the user based on their activities in the system.",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Short code for the badge.",
+                "example": "SupF"
+              },
+              "name": {
+                "type": "string",
+                "description": "Full name of the badge.",
+                "example": "SuperFan"
+              }
+            }
+          },
+          "referralCode": {
+            "type": "string",
+            "example": "ABCD1234"
+          },
+          "referralDiscount": {
+            "type": "number",
+            "description": "Discount value for the referral.",
+            "example": 0.1
+          },
+          "referralDiscountType": {
+            "type": "string",
+            "description": "Type of discount applied",
+            "example": "percentage",
+            "enum": [
+              "percentage",
+              "flat"
+            ]
+          },
+          "referralCount": {
+            "type": "number",
+            "example": 10
+          },
+          "referrerCode": {
+            "type": "string",
+            "example": "absdkfjhdsd"
+          },
+          "referrerDiscount": {
+            "type": "number",
+            "description": "Discount value for the referral.",
+            "example": 100
+          },
+          "referrerDiscountType": {
+            "type": "string",
+            "description": "Type of discount applied",
+            "example": "flat",
+            "enum": [
+              "percentage",
+              "flat"
+            ]
+          },
+          "walletAddress": {
+            "type": "string",
+            "description": "The wallet address of the individual user.",
+            "example": "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          "nextSteps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "verificationLink": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "example": "https://app-kyc.xyz/kyc"
+                    },
+                    "params": {
+                      "type": "object",
+                      "properties": {
+                        "userId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                        },
+                        "redirect": {
+                          "type": "string",
+                          "format": "url",
+                          "example": "https://app-qa.pay.com/kycConfirmation"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "GetKYCErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A general error message.",
+            "example": "Error occurred while retrieving KYC information."
+          },
+          "error": {
+            "type": "string",
+            "description": "A detailed error message for troubleshooting.",
+            "example": "KYC record not found."
+          }
+        }
+      },
+      "MasterType": {
+        "type": "string",
+        "enum": [
+          "Country",
+          "DocumentType",
+          "DepositToken",
+          "CardStatus",
+          "UserRole",
+          "CardProduct",
+          "Consent"
+        ]
+      },
+      "MasterData": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Country",
+              "DocumentType",
+              "DepositToken",
+              "CardStatus",
+              "UserRole",
+              "CardProduct",
+              "Consent"
+            ]
+          },
+          "key": {
+            "type": "string",
+            "example": "IN"
+          },
+          "value": {
+            "type": "string",
+            "example": "India"
+          },
+          "description": {
+            "type": "string",
+            "example": "Country in South Asia"
+          },
+          "isActive": {
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "MasterDataResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A success message for the response.",
+            "example": "Master Data updated successfully"
+          },
+          "data": {
+            "type": "array",
+            "description": "List of naster data.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 1
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Country",
+                    "DocumentType",
+                    "DepositToken",
+                    "CardStatus",
+                    "UserRole",
+                    "CardProduct",
+                    "Consent"
+                  ]
+                },
+                "key": {
+                  "type": "string",
+                  "example": "IN"
+                },
+                "value": {
+                  "type": "string",
+                  "example": "India"
+                },
+                "description": {
+                  "type": "string",
+                  "example": "Country in South Asia"
+                },
+                "isActive": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "ConsumerOccupation": {
+        "type": "object",
+        "description": "Represents a consumer occupation entry.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Unique code identifier for the occupation.",
+            "example": "11-3011"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the occupation.",
+            "example": "Administrative Services Managers"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Indicates if the occupation record is currently active.",
+            "example": true
+          }
+        },
+        "required": [
+          "code",
+          "name",
+          "isActive"
+        ]
+      },
+      "NotificationUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "read": {
+            "type": "boolean",
+            "description": "Whether the notification is read or not",
+            "example": true
+          }
+        }
+      },
+      "NotificationResponse": {
+        "type": "object",
+        "properties": {
+          "notifications": {
+            "type": "array",
+            "description": "List of user notifications",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 1
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Your profile has been updated."
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2024-10-11T12:00:00Z"
+                }
+              }
+            }
+          }
+        }
+      },
+      "NotificationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Error occurred while fetching notifications."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "Unable to retrieve notifications"
+          }
+        }
+      },
+      "CreatePasswordRequest": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "format": "password",
+            "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+            "example": "StrongP@ssw0rd123!"
+          }
+        },
+        "required": [
+          "password"
+        ]
+      },
+      "CreatePasswordErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Failed to create a password. Please ensure your token is valid and try again."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+            "example": "weak password"
+          }
+        }
+      },
+      "CreatePasswordResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Success message",
+            "example": "Password created successfully. You can now sign in."
+          }
+        }
+      },
+      "ChangePasswordRequest": {
+        "type": "object",
+        "properties": {
+          "oldPassword": {
+            "type": "string",
+            "format": "password",
+            "description": "The user's current password",
+            "example": "oldpassword123"
+          },
+          "newPassword": {
+            "type": "string",
+            "format": "password",
+            "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+            "example": "StrongP@ssw0rd123!"
+          }
+        },
+        "required": [
+          "oldPassword",
+          "newPassword"
+        ]
+      },
+      "ChangePasswordResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message for the user",
+            "example": "Password changed successfully."
+          }
+        }
+      },
+      "ChangePasswordErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Error occurred while changing password."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "Old password is incorrect"
+          }
+        }
+      },
+      "ForgotPasswordRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The user's registered email address",
+            "example": "user@example.com"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "ForgotPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message for the user",
+            "example": "Password reset link sent to your email."
+          }
+        }
+      },
+      "ForgotPasswordErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Description of the error that occurred",
+            "example": "Error occurred while sending password reset link."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information (optional)",
+            "example": "User not found"
+          }
+        }
+      },
+      "ResetPasswordRequest": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "format": "password",
+            "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+            "example": "StrongP@ssw0rd123!"
+          }
+        },
+        "required": [
+          "password"
+        ]
+      },
+      "ResetPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message for the user",
+            "example": "Password reset successfully."
+          }
+        }
+      },
+      "ResetPasswordErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Failed to create a password. Please ensure your token is valid and try again."
+          },
+          "error": {
+            "type": "string",
+            "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+            "example": "weak password"
+          }
+        }
+      },
+      "DocumentType": {
+        "type": "string",
+        "enum": [
+          "CERT_INC",
+          "COMP_REG",
+          "SH_REG",
+          "M_REG",
+          "PASSPORT",
+          "DL",
+          "NATIONALID"
+        ]
+      },
+      "DocumentSide": {
+        "type": "string",
+        "enum": [
+          "FRONT",
+          "BACK"
+        ]
+      },
+      "UploadRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the document.",
+            "example": "passport.pdf"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "CERT_INC",
+              "COMP_REG",
+              "SH_REG",
+              "M_REG",
+              "PASSPORT",
+              "DL",
+              "NATIONALID"
+            ]
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "FRONT",
+              "BACK"
+            ]
+          },
+          "country": {
+            "type": "string",
+            "description": "The country associated with the document.",
+            "example": "USA",
+            "maxLength": 3,
+            "minLength": 3
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "UploadResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A message about the success of the upload.",
+            "example": "Document uploaded successfully"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the uploaded file.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        }
+      },
+      "UploadError": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The HTTP status code.",
+            "example": 400
+          },
+          "error": {
+            "type": "string",
+            "description": "A short description of the error.",
+            "example": "Invalid file type"
+          },
+          "message": {
+            "type": "string",
+            "description": "A detailed message about the error.",
+            "example": "Only PDF, JPEG, JPG, and PNG file types are allowed."
+          }
+        }
+      }
+    },
+    "responses": {
+      "UnauthorizedError": {
+        "description": "Access is denied due to invalid or missing token.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Unauthorized access. Token is missing or invalid."
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Invalid or expired token"
+                }
+              }
+            }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "An unexpected error occurred on the server.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Something went wrong on the server. Please try again later."
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ForbiddenError": {
+        "description": "Token expired or not authorized.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "You are not authorized to access this resource. Please log in again."
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Forbidden"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "appKeyAuth": {
+        "type": "apiKey",
+        "name": "x-app-code",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    },
+    {
+      "appKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication",
+      "description": "Operations related to authentication"
+    },
+    {
+      "name": "Captcha",
+      "description": "Initializing and validating Geetest CAPTCHA challenges, used to verify human interaction on the frontend."
+    },
+    {
+      "name": "Password Management",
+      "description": "Operations related to user account password"
+    },
+    {
+      "name": "Two-Factor Authentication",
+      "description": "Operations related to two-factor authentication"
+    },
+    {
+      "name": "KYB",
+      "description": "Operations related to Corporate Customer Application"
+    },
+    {
+      "name": "KYC",
+      "description": "Operations related to Individual Customer Application"
+    },
+    {
+      "name": "Verification",
+      "description": "Operations related to KYB/KYC status"
+    },
+    {
+      "name": "Card Management",
+      "description": "Operations related to cards"
+    },
+    {
+      "name": "Master Management",
+      "description": "Operations related to master Data"
+    },
+    {
+      "name": "User Management",
+      "description": "Operations related to user Data"
+    },
+    {
+      "name": "Wallet",
+      "description": "Operations related to deposits"
+    },
+    {
+      "name": "Transactions",
+      "description": "Operations related to transactions"
+    }
+  ]
+}

--- a/api-reference/corporate.json
+++ b/api-reference/corporate.json
@@ -1,0 +1,17369 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+      "title": "OrbitXPay API",
+      "version": "1.0.0",
+      "description": "\nThis API is designed for managing the functionalities of **OrbitXPay**.\n\n## Authentication\n\nThe API uses **Bearer Token** authentication. All requests to secured endpoints must include the following header:\n\n```\nAuthorization: Bearer <your-token>\n```\n\n### How to Obtain the Token\n1. Authenticate by sending a request to the **`/auth/signin-email`** OR **`/auth/signin-social`** endpoint.\n2. Upon successful authentication, you will receive a Bearer token.\n\n### Error Responses\n- **`401 Unauthorized`**: Returned if the token is missing, invalid, or expired.\n- **`403 Forbidden`**: Returned if the token does not have sufficient permissions to access the requested resource.\n\n---\n\nFor further details, refer to individual endpoints.\n"
+    },
+    "servers": [
+      {
+        "url": "https://api-qa.orbitxpay.com/api/v1",
+        "description": "API server V1"
+      }
+    ],
+    "paths": {
+      "/auth/signup-email": {
+        "post": {
+          "summary": "Register a new user",
+          "description": "This API is used to register a new user in the system. Upon successful registration:\n- The request requires the **x-app-code** header for authentication and the Partner Code to associate the customer to a particular partner.\n- An email containing a verification link is sent to the provided email address.\n- The user must click the verification link to confirm their email address.\n- Until the email is verified, the account will remain inactive.\n- To verify the email, the user needs to call the **Verify Email API** with the verification token sent in the email.\n\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's email address",
+                      "example": "user@example.com"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The user's first name",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The user's last name",
+                      "example": "Doe"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User registered successfully, email verification link sent",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "User registered successfully. Please verify your email."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error",
+                        "example": "A descriptive error message"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Optional detailed error information (only for server errors)",
+                        "example": "Detailed error information"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "MissingFields": {
+                      "summary": "Required fields are missing",
+                      "value": {
+                        "message": "One or more required fields are missing",
+                        "error": "Missing Fields"
+                      }
+                    },
+                    "EmailAlreadyExists": {
+                      "summary": "Email already registered",
+                      "value": {
+                        "message": "Email is already registered",
+                        "error": "Email Already Exists"
+                      }
+                    },
+                    "InvalidEmail": {
+                      "summary": "Email is invalid",
+                      "value": {
+                        "message": "Email is invalid",
+                        "error": "Invalid Email"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/verify-email": {
+        "put": {
+          "summary": "Verify user email address",
+          "description": "This API is used to verify the email address of a user after they click the verification link in their email. \nThe user must provide the verification token received in their email.\n\nUpon successful verification:\n- The user's email is marked as verified in the system.\n- The account will be activated.\n- A **temporary token** will be generated and returned.\n- This temporary token is required to create the user’s password in the next step.\n       \nIf the token is invalid or expired:\n- The user will receive an error response indicating the failure.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "token",
+              "in": "query",
+              "description": "The verification token sent via email",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Email verified successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message indicating the email has been verified.",
+                        "example": "Email verified successfully. Please create your password."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid token",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Error message if the token is invalid or expired",
+                        "example": "Invalid or expired token"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information",
+                        "example": "Verification failed"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "MissingToken": {
+                      "summary": "Verification token missing",
+                      "value": {
+                        "message": "Verification token is required",
+                        "error": "Missing Token"
+                      }
+                    },
+                    "InvalidToken": {
+                      "summary": "Invalid token",
+                      "value": {
+                        "message": "No email accociated with this token",
+                        "error": "Invalid token"
+                      }
+                    },
+                    "AlreadyVerified": {
+                      "summary": "Already Verified",
+                      "value": {
+                        "message": "Email is already verified",
+                        "error": "Already Verified"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signin-email": {
+        "post": {
+          "summary": "Sign in using email and password",
+          "description": "This API allows users to sign in using their email and password after verifying their email and creating a password.  \n- On successful authentication, the API provides an **accessToken** and a **refreshToken** for subsequent requests.  \n- If the system has 2FA enabled for the user, the API will provide a temporary token (**token2fa**) instead of the usual tokens.  \n- The user must then complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's email address",
+                      "example": "user@example.com"
+                    },
+                    "password": {
+                      "type": "string",
+                      "description": "The user's password",
+                      "example": "password123"
+                    }
+                  },
+                  "required": [
+                    "email",
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Sign-in successful",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      },
+                      "token2fa": {
+                        "type": "string",
+                        "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                        "example": "U2FsdGVkX1...",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "examples": {
+                    "No2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                      }
+                    },
+                    "With2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Invalid credentials"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Authentication failed"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Invalid credentials",
+                    "error": "Authentication failed"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signin-social": {
+        "post": {
+          "summary": "Sign in using Google account",
+          "description": "This API allows users to sign in using their Google account.  \n- The user needs to authenticate via Google and provide the **accessToken** returned by Google.  \n- The API will validate the **accessToken** with Google and authenticate the user.  \n- If the system has 2FA enabled for the user, the API will provide a **token2fa** instead of the usual **accessToken** and **refreshToken**.  \n- The user must complete the 2FA process to obtain access and refresh tokens.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "description": "The social provider used for signing in (e.g., google, facebook)",
+                      "example": "google"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "The OAuth token from the social provider",
+                      "example": "eyJhbGciOiJIUzI1..."
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "Long-lived refresh token (used to refresh the access token)",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      },
+                      "token2fa": {
+                        "type": "string",
+                        "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+                        "example": "U2FsdGVkX1...",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "examples": {
+                    "No2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJiOGMwZjBlLTYwNTEtNDkzOC04MjAzLWQxZjNhN2Y3MzhjNSIsImVtYWlsIjoiIiwiaWF0IjoxNzMxODU4NTkzLCJleHAiOjE3MzI0NjMzOTN9.HdGhGMNtZq0Dt4tUWeBSoYrnurx5jOTI7vtqC1scngM"
+                      }
+                    },
+                    "With2FA": {
+                      "value": {
+                        "message": "Successfully authenticated.",
+                        "token2fa": "zY2FyQ87bxZn5KqJr8a35iFdo9j6cO"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Invalid social token"
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Authentication failed"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Invalid credentials",
+                    "error": "Authentication failed"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/signout": {
+        "post": {
+          "summary": "Sign out of the system",
+          "description": "This API allows the user to sign out by invalidating the current `accessToken` and `refreshToken`.  \n- The user will be logged out, and the tokens will no longer be valid.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully signed out",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully signed out"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while signing out"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Token expired or not authorized.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "You are not authorized to access this resource. Please log in again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Forbidden"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/refresh-token": {
+        "put": {
+          "summary": "Refresh user authentication token",
+          "description": "This API allows the user to obtain a new access token and refresh token.\n- The user must provide a valid refresh token to get a new access token.\n- This process ensures that the user's session can continue without needing to sign in again.\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "refreshToken": {
+                      "type": "string",
+                      "description": "The refresh token provided during sign-in *",
+                      "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    }
+                  },
+                  "required": [
+                    "refreshToken"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully refreshed the token",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "accessToken": {
+                        "type": "string",
+                        "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "(Optional) A new refresh token, if a new one is issued",
+                        "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Token expired or not authorized.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "You are not authorized to access this resource. Please log in again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Forbidden"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/create-password": {
+        "post": {
+          "summary": "Create a password for the user after email verification",
+          "description": "This API allows the user to set their password after successfully verifying their email. \nThe user must provide the following details:\n- The **temporary token** received after successful email verification.\n- A new password that will be used to authenticate the user on future logins.\n\nUpon successful creation of the password:\n- The user’s password is saved securely in the system.\n- The account is fully activated, and the user can log in using their new password.\n\nIf the temporary token is invalid or expired:\n- The user will receive an error response indicating the failure.\n- The password creation process will be aborted.\n\nIf the password doesn't meet the required security criteria:\n- The user will be prompted to choose a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "password": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message",
+                        "example": "Password created successfully. You can now sign in."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to create a password. Please ensure your token is valid and try again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                        "example": "weak password"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/change-password": {
+        "post": {
+          "summary": "Change the user’s password",
+          "description": "This API allows an authenticated user to change their existing password.\n\nRequirements:\n- The user must provide their current password for verification.\n- A new password that meets the system's security criteria must be provided.\n\nUpon successful password change:\n- The new password will replace the existing password.\n- The user can use the new password for future logins.\n\nIf the current password is incorrect:\n- The user will receive an error response, and the password will not be updated.\n\nIf the new password does not meet security criteria:\n- The user will be prompted to provide a stronger password.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "oldPassword": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The user's current password",
+                      "example": "oldpassword123"
+                    },
+                    "newPassword": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "oldPassword",
+                    "newPassword"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password changed successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password changed successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while changing password."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Old password is incorrect"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    },
+                    "IncorrectOldPassword": {
+                      "summary": "Incorrect Old Password",
+                      "value": {
+                        "message": "Old password is incorrect.",
+                        "error": "Incorrect Old Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/forgot-password": {
+        "post": {
+          "summary": "Initiate the password reset process",
+          "description": "This API allows a user to request a password reset link or token if they have forgotten their password.\n\nWorkflow:\n- The user provides their registered email address.\n- If the email exists in the system:\n  - A password reset link or token is sent to the provided email.\n  - The user can use this link/token to reset their password.\n- If the email does not exist:\n  - For security purposes, a generic success message is returned (to prevent email enumeration).\n\nThe email will contain:\n- A secure token.\n- Instructions to reset the password.\n\nIf the email sending fails:\n- An error response will be provided.\n\nUpon successful email delivery, the user will receive a confirmation response.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The user's registered email address",
+                      "example": "user@example.com"
+                    }
+                  },
+                  "required": [
+                    "email"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset link sent",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password reset link sent to your email."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while sending password reset link."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "User not found"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while sending password reset link.",
+                    "error": "User not found"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/reset-password": {
+        "post": {
+          "summary": "Reset user password using a valid reset token",
+          "description": "This API allows a user to reset their password using the password reset token received in the password reset email.\nWorkflow:\n- The user provides:\n  - A valid password reset token.\n  - A new password that meets the system’s security criteria.\n- If the token is valid and not expired:\n  - The user's password is securely updated in the system.\n  - The token is invalidated to prevent reuse.\n- If the token is invalid or expired:\n  - An error response is returned.\n\nUpon successful password reset:\n- The user will be able to log in with the new password.\n\nSecurity Considerations:\n- The reset token must be validated for authenticity and expiration.\n- The new password should meet all required security criteria.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Password Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "password": {
+                      "type": "string",
+                      "format": "password",
+                      "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                      "example": "StrongP@ssw0rd123!"
+                    }
+                  },
+                  "required": [
+                    "password"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Password reset successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Password reset successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to create a password. Please ensure your token is valid and try again."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+                        "example": "weak password"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "WeakPassword": {
+                      "summary": "Weak Password",
+                      "value": {
+                        "message": "Password should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+                        "error": "Weak Password"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/captcha-challenge": {
+        "get": {
+          "summary": "Get CAPTCHA configuration",
+          "description": "Initializes Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+          "tags": [
+            "Captcha"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "CAPTCHA initialized successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha challenge initialized successfully."
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "data": {
+                        "type": "object",
+                        "properties": {
+                          "lot_number": {
+                            "type": "string",
+                            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                          },
+                          "captcha_type": {
+                            "type": "string",
+                            "example": "slide"
+                          },
+                          "captcha_output": {
+                            "type": "string",
+                            "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+                          },
+                          "pass_token": {
+                            "type": "string",
+                            "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+                          },
+                          "captcha_id": {
+                            "type": "string",
+                            "example": "fb362ff464a632747b0dd0ea90bab013"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        },
+        "post": {
+          "summary": "Validate CAPTCHA configuration",
+          "description": "Validate Geetest CAPTCHA by returning the configuration required to render it on the frontend.\n\nThis public endpoint does **not** require authentication but needs specific headers to determine the partner and application context.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner making the request.\n- **x-app-code**: Authenticates the app initiating the CAPTCHA challenge.\n",
+          "tags": [
+            "Captcha"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mobile": {
+                      "type": "string",
+                      "example": "9456262167"
+                    },
+                    "captcha_id": {
+                      "type": "string",
+                      "example": "d81db9ghjk82bc8abb8b93a6b24b"
+                    },
+                    "lot_number": {
+                      "type": "string",
+                      "example": "362ff4642747b0dd0ea90bab013ss"
+                    },
+                    "captcha_output": {
+                      "type": "string",
+                      "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+                    },
+                    "pass_token": {
+                      "type": "string",
+                      "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+                    },
+                    "gen_time": {
+                      "type": "string",
+                      "example": "1747751473"
+                    }
+                  },
+                  "required": [
+                    "mobile",
+                    "captcha_id",
+                    "lot_number",
+                    "captcha_output",
+                    "pass_token",
+                    "gen_time"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "CAPTCHA validated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha validated successfully."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Captcha validation failed."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "pass_token expire"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/verify-login-2fa": {
+        "post": {
+          "summary": "Verify login with 2FA (token and OTP)",
+          "description": "This API verifies the 2FA during the login process.\n- After successfully logging in with email/password or social sign-in, if 2FA is enabled, the user must provide the 2FA token.\n- The user needs to provide the OTP (One-Time Password) from their authenticator app to complete the login process.\n- The 2FA token is verified and if successful, the user is granted access and provided with JWT tokens (accessToken, refreshToken).\n\n**Headers**:\n\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token2fa": {
+                      "type": "string",
+                      "description": "Encrypted token containing the user data for 2FA.\nThis is used to validate the 2FA during login.\n",
+                      "example": "U2FsdGVkX1..."
+                    },
+                    "otp": {
+                      "type": "string",
+                      "description": "The one-time password (OTP) generated by the authenticator app (e.g., Google Authenticator).\nThis is required to complete the 2FA verification process.\n",
+                      "example": "123456"
+                    }
+                  },
+                  "required": [
+                    "token2fa",
+                    "otp"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      },
+                      "accessToken": {
+                        "type": "string",
+                        "description": "JWT access token that the user can use for subsequent requests.",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                      },
+                      "refreshToken": {
+                        "type": "string",
+                        "description": "JWT refresh token used to get a new access token after expiration.",
+                        "example": "eyJhbGciOiJIUzI1NiIsInR..."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Invalid token or OTP",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid 2FA token or OTP."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      },
+      "/auth/generate-2fa": {
+        "get": {
+          "summary": "Generate 2FA secret key and QR code for the user",
+          "description": "This API generates a new 2FA secret key for the user, which can be used with an authenticator app (e.g., Google Authenticator).\nIt also returns the QR code data as a Base64 string, which can be scanned by the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA secret and QR code generated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Success message",
+                        "example": "2FA secret generated successfully."
+                      },
+                      "qrCodeData": {
+                        "type": "string",
+                        "description": "QR code image data for scanning",
+                        "example": "data:image/png;base64,iVBORw0..."
+                      },
+                      "secret": {
+                        "type": "string",
+                        "description": "The secret, in case user wants to manually enter it",
+                        "example": "JBSWY3DPEHPK3PXP"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/enable-2fa": {
+        "post": {
+          "summary": "Enable 2FA for the user",
+          "description": "This API enables 2FA for the user by verifying the OTP generated by their authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "token generated by the user's authenticator app",
+                      "example": 123456
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "2FA enabled successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Confirmation message for the user",
+                        "example": "Two-factor authentication enabled successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while enabling two-factor authentication."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Error message if OTP verification fails",
+                        "example": "Invalid OTP. Please try again."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while enabling two-factor authentication.",
+                    "error": "Invalid code or secret"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/verify-2fa": {
+        "post": {
+          "summary": "Verify 2FA OTP for sensitive information access",
+          "description": "This API is used to verify the OTP from the user's authenticator app for sensitive operations such as accessing confidential data.\nThis is a separate verification step and should be used whenever 2FA is required to access specific, sensitive information.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "The one-time password (OTP) sent to the user.",
+                      "example": "123456",
+                      "maxLength": 6,
+                      "minLength": 6
+                    }
+                  },
+                  "required": [
+                    "token"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully authenticated",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully authenticated."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Invalid OTP",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid OTP."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/status-2fa": {
+        "get": {
+          "summary": "Retrieve the 2FA status of the user",
+          "description": "This API returns the current 2FA status of the user, indicating whether 2FA is enabled or not.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA status retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "2FA Enabled for this user"
+                      },
+                      "status": {
+                        "type": "boolean",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/auth/disable-2fa": {
+        "put": {
+          "summary": "Disable 2FA for the user",
+          "description": "This API disables 2FA for the user by verifying the OTP from the authenticator app.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Two-Factor Authentication"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "2FA disabled successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "2FA disabled successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb": {
+        "post": {
+          "summary": "Initiate the application process for corporate customers",
+          "description": "This API is used to initiate the application process for corporate customers.\n\nWorkflow:\n- The API accepts the initial details required to start the corporate customer application.\n- Once initiated, the system assigns a unique application ID and marks the application as pending further inputs.\n\nKey Notes:\n- This process is specific to corporate customers.\n- The application will require further steps to complete, such as uploading documents, filling additional details, etc.\n- Notifications or progress updates will be sent to the user’s registered email or dashboard.\n\nUpon successful initiation:\n- The API returns the unique application ID and status.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "initialUser": {
+                      "type": "object",
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The initial user of the company",
+                          "properties": {
+                            "role": {
+                              "type": "string",
+                              "description": "This user's role at their company"
+                            },
+                            "walletAddress": {
+                              "type": "string",
+                              "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                            },
+                            "ipAddress": {
+                              "type": "string",
+                              "description": "The user's IP address"
+                            },
+                            "iovationBlackbox": {
+                              "type": "string",
+                              "description": "A blackbox string generated by the client side Iovation library"
+                            }
+                          },
+                          "required": [
+                            "iovationBlackbox",
+                            "ipAddress",
+                            "isTermsOfServiceAccepted"
+                          ]
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the company looking to create an account"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The company's physical address"
+                        }
+                      ]
+                    },
+                    "chainId": {
+                      "type": "string",
+                      "description": "the chain id of the company's external collateral contract"
+                    },
+                    "contractAddress": {
+                      "type": "string",
+                      "description": "the address of the company's external collateral contract;"
+                    },
+                    "entity": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    },
+                    "representatives": {
+                      "type": "array",
+                      "description": "The company's representatives",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    },
+                    "ultimateBeneficialOwners": {
+                      "type": "array",
+                      "description": "The company's ultimate beneficial owners",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "initialUser",
+                    "name",
+                    "address",
+                    "entity",
+                    "representatives",
+                    "ultimateBeneficialOwners"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information saved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "Indicates the form is in draft mode.",
+                        "example": "Pending",
+                        "enum": [
+                          "PENDING"
+                        ]
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "Message providing more information about the draft status.",
+                        "example": "KYB information saved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique ID for tracking the draft submission.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "ISO timestamp of the last update.",
+                        "example": "2024-10-14T12:34:56Z"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "General message about the validation error.",
+                        "example": "Validation Failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "The form field with the issue.",
+                              "example": "businessName"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Description of the validation error.",
+                              "example": "The business name is required."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/{id}": {
+        "get": {
+          "summary": "Retrieve corporate customer application details",
+          "description": "This API is used to fetch the details of an existing corporate customer application.\n       \nKey Notes:\n- Returns detailed information about the application, including the status and all submitted details.\n- If the `id` does not exist, the API will return an appropriate error message.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "KYB information retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A success message for the response.",
+                        "example": "KYB information retrieved successfully."
+                      },
+                      "kybData": {
+                        "type": "object",
+                        "description": "The KYB information retrieved for the company.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique ID of the KYB draft.",
+                            "example": "550e8400-e29b-41d4-a716-446655440000"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the company.",
+                            "example": "Acme Corp"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The company's physical address"
+                              }
+                            ]
+                          },
+                          "chainId": {
+                            "type": "string",
+                            "description": "the chain id of the company's external collateral contract"
+                          },
+                          "documents": {
+                            "type": "array",
+                            "description": "List of KYB documents.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "Name of the document",
+                                  "example": "passport_image.png"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                                  "example": "CERT_INC"
+                                },
+                                "side": {
+                                  "type": "string",
+                                  "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                                  "example": "front, back"
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                                  "example": "USA",
+                                  "maxLength": 3
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "entity": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The legal entity's name"
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "The legal entity's type - LLC, S Corp, etc."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "A brief description of the legal entity, and its activities"
+                              },
+                              "taxId": {
+                                "type": "string",
+                                "description": "The legal entity's national tax id"
+                              },
+                              "registrationNumber": {
+                                "type": "string",
+                                "description": "The legal entity's registration number"
+                              },
+                              "website": {
+                                "type": "string",
+                                "description": "The legal entity's website"
+                              },
+                              "expectedSpend": {
+                                "type": "string",
+                                "description": "How much the legal entity expects to spend each month"
+                              },
+                              "industry": {
+                                "type": "string",
+                                "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "taxId",
+                              "registrationNumber",
+                              "website"
+                            ]
+                          },
+                          "representatives": {
+                            "type": "array",
+                            "description": "List of company representatives.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "description": "The person's first name",
+                                  "maxLength": 50
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "description": "The person's last name",
+                                  "maxLength": 50
+                                },
+                                "birthDate": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The person's birth date"
+                                },
+                                "nationalId": {
+                                  "type": "string",
+                                  "description": "National ID (9-digit SSN for US users)"
+                                },
+                                "countryOfIssue": {
+                                  "type": "string",
+                                  "description": "2-letter country code where the ID was issued",
+                                  "maxLength": 2
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "The person's email address"
+                                },
+                                "address": {
+                                  "allOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "Auto-generated UUID for the document",
+                                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                        },
+                                        "line1": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "line2": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "city": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "maxLength": 60
+                                        },
+                                        "postalCode": {
+                                          "type": "string",
+                                          "maxLength": 15
+                                        },
+                                        "countryCode": {
+                                          "type": "string",
+                                          "maxLength": 2
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        }
+                                      },
+                                      "required": [
+                                        "line1",
+                                        "city",
+                                        "region",
+                                        "postalCode",
+                                        "countryCode",
+                                        "country"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "description": "The person's address"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "firstName",
+                                "lastName",
+                                "birthDate",
+                                "nationalId",
+                                "countryOfIssue",
+                                "email",
+                                "address"
+                              ]
+                            }
+                          },
+                          "ultimateBeneficialOwners": {
+                            "type": "array",
+                            "description": "List of the company's ultimate beneficial owners.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "description": "The person's first name",
+                                  "maxLength": 50
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "description": "The person's last name",
+                                  "maxLength": 50
+                                },
+                                "birthDate": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The person's birth date"
+                                },
+                                "nationalId": {
+                                  "type": "string",
+                                  "description": "National ID (9-digit SSN for US users)"
+                                },
+                                "countryOfIssue": {
+                                  "type": "string",
+                                  "description": "2-letter country code where the ID was issued",
+                                  "maxLength": 2
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "format": "email",
+                                  "description": "The person's email address"
+                                },
+                                "address": {
+                                  "allOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "Auto-generated UUID for the document",
+                                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                        },
+                                        "line1": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "line2": {
+                                          "type": "string",
+                                          "maxLength": 100
+                                        },
+                                        "city": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "maxLength": 60
+                                        },
+                                        "postalCode": {
+                                          "type": "string",
+                                          "maxLength": 15
+                                        },
+                                        "countryCode": {
+                                          "type": "string",
+                                          "maxLength": 2
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "maxLength": 50
+                                        }
+                                      },
+                                      "required": [
+                                        "line1",
+                                        "city",
+                                        "region",
+                                        "postalCode",
+                                        "countryCode",
+                                        "country"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "description": "The person's address"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "firstName",
+                                "lastName",
+                                "birthDate",
+                                "nationalId",
+                                "countryOfIssue",
+                                "email",
+                                "address"
+                              ]
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "The current status of the KYB process.",
+                            "example": "Pending"
+                          },
+                          "referralCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "referralCount": {
+                            "type": "number",
+                            "example": 10
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message.",
+                        "example": "Error occurred while retrieving KYB information."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A detailed error message for troubleshooting.",
+                        "example": "KYB record not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update details of a corporate customer application",
+          "description": "This API is used to update the details of an existing corporate customer application.\n\nWorkflow:\n- Provide the unique application ID and the updated fields.\n- Only editable fields can be modified;\n\nKey Notes:\n- The application must exist in the system.\n- If the application is already submitted for review, updates will be restricted.\n\nUpon successful update:\n- The application details are updated, and the new data is stored in the system.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "initialUser": {
+                      "type": "object",
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The initial user of the company",
+                          "properties": {
+                            "role": {
+                              "type": "string",
+                              "description": "This user's role at their company"
+                            },
+                            "walletAddress": {
+                              "type": "string",
+                              "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                            },
+                            "ipAddress": {
+                              "type": "string",
+                              "description": "The user's IP address"
+                            },
+                            "iovationBlackbox": {
+                              "type": "string",
+                              "description": "A blackbox string generated by the client side Iovation library"
+                            }
+                          },
+                          "required": [
+                            "iovationBlackbox",
+                            "ipAddress",
+                            "isTermsOfServiceAccepted"
+                          ]
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the company looking to create an account"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The company's physical address"
+                        }
+                      ]
+                    },
+                    "chainId": {
+                      "type": "string",
+                      "description": "the chain id of the company's external collateral contract"
+                    },
+                    "contractAddress": {
+                      "type": "string",
+                      "description": "the address of the company's external collateral contract;"
+                    },
+                    "entity": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    },
+                    "representatives": {
+                      "type": "array",
+                      "description": "The company's representatives",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    },
+                    "ultimateBeneficialOwners": {
+                      "type": "array",
+                      "description": "The company's ultimate beneficial owners",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "description": "The person's first name",
+                            "maxLength": 50
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "description": "The person's last name",
+                            "maxLength": 50
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The person's birth date"
+                          },
+                          "nationalId": {
+                            "type": "string",
+                            "description": "National ID (9-digit SSN for US users)"
+                          },
+                          "countryOfIssue": {
+                            "type": "string",
+                            "description": "2-letter country code where the ID was issued",
+                            "maxLength": 2
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "The person's email address"
+                          },
+                          "address": {
+                            "allOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "Auto-generated UUID for the document",
+                                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "maxLength": 60
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "maxLength": 15
+                                  },
+                                  "countryCode": {
+                                    "type": "string",
+                                    "maxLength": 2
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "maxLength": 50
+                                  }
+                                },
+                                "required": [
+                                  "line1",
+                                  "city",
+                                  "region",
+                                  "postalCode",
+                                  "countryCode",
+                                  "country"
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "description": "The person's address"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "firstName",
+                          "lastName",
+                          "birthDate",
+                          "nationalId",
+                          "countryOfIssue",
+                          "email",
+                          "address"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "initialUser",
+                    "name",
+                    "address",
+                    "entity",
+                    "representatives",
+                    "ultimateBeneficialOwners"
+                  ]
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information saved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "Indicates the form is in draft mode.",
+                        "example": "Pending",
+                        "enum": [
+                          "PENDING"
+                        ]
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "Message providing more information about the draft status.",
+                        "example": "KYB information saved successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique ID for tracking the draft submission.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      },
+                      "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "ISO timestamp of the last update.",
+                        "example": "2024-10-14T12:34:56Z"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "403": {
+              "description": "Updation Not Allowed for Pending or Verified Users",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Updation not allowed for users with pending or verified status."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "patch": {
+          "summary": "Perform a partial update on a corporate customer application",
+          "description": "This API is used for partial updates to a corporate customer application.\nSpecifically, it allows removing **one representative** and/or **one ultimate beneficial owner (UBO)** from an existing application.\n\nWorkflow:\n- Provide the unique **id** along with a single **representative** or **ultimateBeneficialOwner** to be removed.\n\nKey Notes:\n- If the application is already submitted for review, updates will be restricted.\n- Only one **representative** and/or one **ultimateBeneficialOwner** can be removed at a time..\n- Fields provided in the request body will be removed only; other application details remain unaffected.\n- The API only removes existing entries. If a provided entry does not exist, the API will return an error.\n\nUpon successful update:\n- The specified entry (representative or UBO) is removed from the application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Partial update data to remove representatives or ultimate Beneficial Owners",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "representativeId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The ID of the representative to remove"
+                    },
+                    "uboId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The ID of the ultimate beneficial owner to remove *"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "KYB information updated successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "KYB information updated successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request - Invalid input or missing required fields.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message.",
+                        "example": "Error occurred while retrieving KYB information."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A detailed error message for troubleshooting.",
+                        "example": "KYB record not found."
+                      }
+                    }
+                  },
+                  "examples": {
+                    "representativeNotFound": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Representative not found"
+                      }
+                    },
+                    "uboNotFound": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Ultimate Beneficial Owner not found"
+                      }
+                    },
+                    "invalidData": {
+                      "value": {
+                        "message": "Error occurred while retrieving KYB information.",
+                        "error": "Invalid data provided"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/submit/{id}": {
+        "put": {
+          "summary": "Submit a corporate customer application for review",
+          "description": "This API is used to submit a corporate customer application for review after all verification steps are complete.\n\n**Workflow**:\n- Ensure the application contains all mandatory fields in the required format, including user information, company information, documents, UBOs, and representatives (if applicable).\n- After the required data is validated, the application will be submitted for internal review.\n\n**Key Notes**:\n- The application will be processed, and any missing or incorrect information will result in a validation error.\n- Once submitted, no further updates will be allowed unless the application is returned for revision.\n- The action finalizes the application and makes it ready for review by the designated team.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Terms of Service Agreement. The user must accept the terms before submitting the application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isTermsOfServiceAccepted": {
+                      "type": "boolean",
+                      "description": "Indicates whether the user has accepted the Terms of Service."
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Corporate customer application submitted successfully for review.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A message providing more information about the submission.",
+                        "example": "KYB form submitted successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request - Missing or invalid terms acceptance or incomplete application data.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "General message about the validation error.",
+                        "example": "Validation Failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "description": "The form field with the issue.",
+                              "example": "businessName"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Description of the validation error.",
+                              "example": "The business name is required."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/profile": {
+        "get": {
+          "summary": "Retrieve the customer profile details",
+          "description": "This API returns the profile information of the authenticated customer.\n- Returns information related to the customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved user profile",
+              "content": {
+                "application/json": {
+                  "schema": {},
+                  "examples": {
+                    "corporate": {
+                      "summary": "Corporate customer profile",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "name": "Company Name",
+                        "status": "pending",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "line2": "DEF Area",
+                          "city": "XYZ",
+                          "region": "Region",
+                          "postalCode": "123456",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "company": {
+                          "name": "Entity Name",
+                          "type": "Entity Type",
+                          "description": "Entity Description",
+                          "taxId": "1234567890",
+                          "registrationNumber": "1234567890",
+                          "website": "https://www.example.com",
+                          "expectedSpend": 123456
+                        },
+                        "documents": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "name": "Document Name",
+                            "type": "Document Type",
+                            "side": "Document Side",
+                            "country": "Document Country",
+                            "size": 123456
+                          }
+                        ],
+                        "representatives": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "firstName": "Representative Name",
+                            "lastName": "Representative Last Name",
+                            "birthDate": "1990-01-01",
+                            "nationalId": "1234567890",
+                            "countryOfIssue": "IN",
+                            "email": "representative@rep.com",
+                            "address": {
+                              "line1": "123, ABC Street",
+                              "line2": "DEF Area",
+                              "city": "XYZ",
+                              "region": "Region",
+                              "postalCode": "123456",
+                              "countryCode": "IN",
+                              "country": "India"
+                            }
+                          }
+                        ],
+                        "ultimateBeneficialOwners": [
+                          {
+                            "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                            "firstName": "UBO Name",
+                            "lastName": "UNO Last Name",
+                            "birthDate": "1990-01-01",
+                            "nationalId": "1234567890",
+                            "countryOfIssue": "IN",
+                            "email": "ubo@ubo.com",
+                            "address": {
+                              "line1": "123, ABC Street",
+                              "line2": "DEF Area",
+                              "city": "XYZ",
+                              "region": "Region",
+                              "postalCode": "123456",
+                              "countryCode": "IN",
+                              "country": "India"
+                            }
+                          }
+                        ],
+                        "user": {
+                          "firstName": "User Name",
+                          "lastName": "User Last Name",
+                          "birthDate": "1990-01-01",
+                          "nationalId": "1234567890",
+                          "countryOfIssue": "IN",
+                          "email": "user@user.com",
+                          "address": {
+                            "line1": "123, ABC Street",
+                            "line2": "DEF Area",
+                            "city": "XYZ",
+                            "region": "Region",
+                            "postalCode": "123456",
+                            "countryCode": "IN",
+                            "country": "India"
+                          },
+                          "walletAddress": "0x1234567890",
+                          "ipAddresse": "0.0.0.0",
+                          "iovationBlackBox": "1234567890"
+                        },
+                        "referralCode": "ABCD1234",
+                        "referralCount": 10
+                      }
+                    },
+                    "individualPending": {
+                      "summary": "Individual customer profile with pending status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "pending",
+                        "nextSteps": [
+                          {
+                            "verificationLink": {
+                              "url": "https://www.example.com",
+                              "params": {
+                                "userId": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "individualapproved": {
+                      "summary": "Individual customer profile with approved status",
+                      "value": {
+                        "message": "Profile retrieved successfully.",
+                        "id": "5f7b1b7b-7b7b-4b7b-8b7b-7b7b7b7b7b7b",
+                        "firstName": "User Name",
+                        "lastName": "User Last Name",
+                        "email": "user@kyc.com",
+                        "address": {
+                          "line1": "123, ABC Street",
+                          "city": "XYZ",
+                          "countryCode": "IN",
+                          "country": "India"
+                        },
+                        "phoneCountryCode": "+91",
+                        "phoneNumber": "1234567890",
+                        "walletAddress": "0x1234567890",
+                        "status": "approved"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A general error message for the failed profile retrieval.",
+                        "example": "Error occurred while retrieving the profile."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information to assist in troubleshooting.",
+                        "example": "Profile not found."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while fetching user profile.",
+                    "error": "User not found"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/upload/{id}": {
+        "post": {
+          "summary": "Upload a document for a customer application",
+          "description": "This API allows uploading documents for a customer application.\n- Provide the application ID and upload a document related to the customer.\n- Ensure the document is of an allowed format (e.g., PDF, JPG, JPEG, PNG).\n- The document must be relevant to the application (e.g., identification proof, financial documents).\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID for the document",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "document": {
+                      "type": "string",
+                      "format": "binary",
+                      "description": "The file to be uploaded"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the document.",
+                      "example": "passport.pdf"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "CERT_INC",
+                        "COMP_REG",
+                        "SH_REG",
+                        "M_REG",
+                        "PASSPORT",
+                        "DL",
+                        "NATIONALID"
+                      ]
+                    },
+                    "side": {
+                      "type": "string",
+                      "enum": [
+                        "FRONT",
+                        "BACK"
+                      ]
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "The country associated with the document.",
+                      "example": "USA",
+                      "maxLength": 3,
+                      "minLength": 3
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Document uploaded successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "A message about the success of the upload.",
+                        "example": "Document uploaded successfully"
+                      },
+                      "documentId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The id of the uploaded file.",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid input or upload error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "description": "The HTTP status code.",
+                        "example": 400
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "A short description of the error.",
+                        "example": "Invalid file type"
+                      },
+                      "message": {
+                        "type": "string",
+                        "description": "A detailed message about the error.",
+                        "example": "Only PDF, JPEG, JPG, and PNG file types are allowed."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/kyb/upload/{id}/{documentId}": {
+        "get": {
+          "summary": "Retrieve a specific document as a binary file",
+          "description": "This API retrieves a file associated with a customer application, identified by the **id** (customer application ID) and **documentId**.\n- The document is returned as a binary file (blob).\n- The file is available for download or direct streaming depending on your use case.\n- Ensure both **id** and **documentId** are valid to retrieve the correct document.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID to which the document belongs.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "documentId",
+              "in": "path",
+              "description": "The ID of the document to be deleted.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "File retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "File retrieved successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Document not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "error": {
+                        "type": "string",
+                        "example": "File not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "delete": {
+          "summary": "Delete a document associated with a customer application",
+          "description": "This API deletes a specific document related to the customer application, identified by the provided **id** and **documentId**.\n- Ensure the correct **id** (customer application ID) and `documentId` are provided.\n- The document will be permanently removed from the system.\n- This operation is irreversible.\n- A success message is returned if the document is successfully deleted, otherwise, appropriate error messages will be shown.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "KYB"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The Customer Application ID to which the document belongs.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "documentId",
+              "in": "path",
+              "description": "The ID of the document to be deleted.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Document deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "File deleted successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Document not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "error": {
+                        "type": "string",
+                        "example": "File not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/verification/status": {
+        "get": {
+          "summary": "Retrieve the verification status of a customer application",
+          "description": "This API retrieves the verification status of customer application.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Verification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved the customer application verification status",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "pending",
+                        "enum": [
+                          "notStarted",
+                          "pending",
+                          "pendingEmailVerification",
+                          "emailVerified",
+                          "saved",
+                          "needsVerification",
+                          "verificationPending",
+                          "underReview",
+                          "manualReview",
+                          "needsInformation",
+                          "verified",
+                          "rejected",
+                          "cancelled",
+                          "denied",
+                          "locked"
+                        ]
+                      }
+                    }
+                  },
+                  "examples": {
+                    "corporatePending": {
+                      "summary": "Corporate Customer Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "corporateUnderReview": {
+                      "summary": "Corporate Customer Under Review Status",
+                      "value": {
+                        "status": "underReview"
+                      }
+                    },
+                    "corporateVerified": {
+                      "summary": "Corporate Customer Verified Status",
+                      "value": {
+                        "status": "verified"
+                      }
+                    },
+                    "individualPending": {
+                      "summary": "Individual Customer Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "individualPendingEmailVerification": {
+                      "summary": "Individual Customer Pending Email Verification Status",
+                      "value": {
+                        "status": "pendingEmailVerification"
+                      }
+                    },
+                    "individualEmailVerified": {
+                      "summary": "Individual Customer Email Verified Status",
+                      "value": {
+                        "status": "emailVerified"
+                      }
+                    },
+                    "individualSaved": {
+                      "summary": "Individual Customer Saved Status",
+                      "value": {
+                        "status": "saved"
+                      }
+                    },
+                    "individualVerificationPending": {
+                      "summary": "Individual Customer Verification Pending Status",
+                      "value": {
+                        "status": "pending"
+                      }
+                    },
+                    "individualUnderReview": {
+                      "summary": "Individual Customer Under Review Status",
+                      "value": {
+                        "status": "underReview"
+                      }
+                    },
+                    "individualVerified": {
+                      "summary": "Individual Customer Verified Status",
+                      "value": {
+                        "status": "verified"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Status not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "example": "MISSING_INFORMATION"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Additional business details required."
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Status not found.",
+                    "error": "Invalid request"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user": {
+        "get": {
+          "summary": "Get all users",
+          "description": "Retrieve a list of all users, with optional filters for search, pagination, and specific user ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "The page number for pagination (default is 1).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "1"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "The number of items per page for pagination (default is 10).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "10"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "Search users by first name, last name, or email.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "John"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of users retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "List of users retrieved successfully"
+                      },
+                      "users": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "04e73427-5c71-44f3-bf7c-4e36c21f876c"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "example": "Test"
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "example": "QA"
+                            },
+                            "email": {
+                              "type": "string",
+                              "example": "test11@tdddest.com"
+                            },
+                            "roleCode": {
+                              "type": "string",
+                              "example": "EMPLOYEE"
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "example": "2001-10-10"
+                            },
+                            "status": {
+                              "type": "string",
+                              "example": "pending",
+                              "enum": [
+                                "approved",
+                                "rejected",
+                                "pending"
+                              ]
+                            },
+                            "cardIssued": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        }
+                      },
+                      "totalItems": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "page": {
+                        "type": "string",
+                        "example": "1"
+                      },
+                      "limit": {
+                        "type": "string",
+                        "example": "10"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No users found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "No users found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Create a new user",
+          "description": "Create a new user with the provided details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "User creation details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "example": "Doe"
+                    },
+                    "email": {
+                      "type": "string",
+                      "example": "john.doe@example.com"
+                    },
+                    "roleCode": {
+                      "type": "string",
+                      "example": "EMPLOYEE"
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "example": "2001-10-10"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User created successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User created successfully"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "example": "Doe"
+                          },
+                          "email": {
+                            "type": "string",
+                            "example": "john.doe@example.com"
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "example": "2001-10-10"
+                          },
+                          "roleCode": {
+                            "type": "string",
+                            "example": "EMPLOYEE"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "approved",
+                            "enum": [
+                              "approved",
+                              "rejected",
+                              "pending"
+                            ]
+                          },
+                          "cardIssued": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "roleCode"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "roleCode is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "summary": "Customer Not Found",
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "validationFailure": {
+                      "summary": "Validation Error",
+                      "value": {
+                        "message": "Unable to save user because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "roleCode",
+                            "message": "roleCode is required"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate is required"
+                          }
+                        ]
+                      }
+                    },
+                    "dateOfBirthValidationError": {
+                      "summary": "Date of Birth Validation Error",
+                      "value": {
+                        "message": "Unable to save user because of the birth validation failures",
+                        "errors": [
+                          {
+                            "field": "birthDate",
+                            "message": "Birth date must be after 1900-01-01"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate must be yyyy-mm-dd format"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "User must be at least 18 years old"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate must be a valid date"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}": {
+        "get": {
+          "summary": "Get user by ID",
+          "description": "Retrieve detailed information about a specific user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to retrieve",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User details retrieved successfully"
+                      },
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "example": "John"
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "example": "Doe"
+                          },
+                          "email": {
+                            "type": "string",
+                            "example": "john.doe@example.com"
+                          },
+                          "roleCode": {
+                            "type": "string",
+                            "example": "EMPLOYEE"
+                          },
+                          "birthDate": {
+                            "type": "string",
+                            "example": "2001-10-10"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "approved",
+                            "enum": [
+                              "approved",
+                              "rejected",
+                              "pending"
+                            ]
+                          },
+                          "cardIssued": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update user details",
+          "description": "Modify specific details of a user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to update",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "User update details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "example": "Doe"
+                    },
+                    "email": {
+                      "type": "string",
+                      "example": "john.doe@example.com"
+                    },
+                    "roleCode": {
+                      "type": "string",
+                      "example": "EMPLOYEE"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "User updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User updated successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Customer not found"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "roleCode"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "roleCode is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    },
+                    "validationFailure": {
+                      "value": {
+                        "message": "Unable to save user because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "roleCode",
+                            "message": "roleCode is required"
+                          },
+                          {
+                            "field": "birthDate",
+                            "message": "birthDate cannot be updated"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "delete": {
+          "summary": "Delete a user",
+          "description": "Delete a specific user by their ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "User Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user to delete",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User deleted successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "userIdInvalid": {
+                      "value": {
+                        "message": "User Not Found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/cards": {
+        "get": {
+          "summary": "Get all cards for all users",
+          "description": "Retrieve a list of all cards associated with users, with optional filters for pagination.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "The page number for pagination (default is 1).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "1"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "The number of items per page for pagination (default is 10).",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "4"
+              }
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "description": "Search users by first name, last name, or email.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "John"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of cards retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully retrieved all cards."
+                      },
+                      "cards": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "f77d55d1-1f83-41a4-817f-a205974fb0ff"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "virtual"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Current status of the card.",
+                              "example": "notActivated",
+                              "enum": [
+                                "notActivated",
+                                "active",
+                                "locked",
+                                "canceled"
+                              ]
+                            },
+                            "last4Digits": {
+                              "type": "string",
+                              "example": "0000"
+                            },
+                            "expirationMonth": {
+                              "type": "string",
+                              "example": "00"
+                            },
+                            "expirationYear": {
+                              "type": "string",
+                              "example": "0000"
+                            },
+                            "productType": {
+                              "type": "string",
+                              "example": "PLATINUM",
+                              "enum": [
+                                "PLATINUM"
+                              ]
+                            },
+                            "productScheme": {
+                              "type": "string",
+                              "example": "VISA",
+                              "enum": [
+                                "VISA"
+                              ]
+                            },
+                            "productCode": {
+                              "type": "string",
+                              "example": "ABCD1234"
+                            },
+                            "cardName": {
+                              "type": "string",
+                              "example": "Regular"
+                            },
+                            "cardMaterial": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "cardMaterialName": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "isPinActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "orderNumber": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "orderDate": {
+                              "type": "Date",
+                              "example": "2025-04-23T17:53:52.000Z"
+                            },
+                            "cardHolder": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "example": "68c44898-a805-4d44-8c6d-3e9367343e96"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "example": "Vest"
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "example": "QA"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "total": {
+                        "type": "integer",
+                        "example": 11
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 3
+                      },
+                      "limit": {
+                        "type": "string",
+                        "example": "4"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "success": {
+                      "summary": "Successfully retrieved all cards",
+                      "value": {
+                        "message": "Successfully retrieved all cards.",
+                        "cards": [
+                          {
+                            "id": "f77d55d1-1f83-41a4-817f-a205974fb0ff",
+                            "type": "virtual",
+                            "status": "notActivated",
+                            "last4Digits": "0000",
+                            "expirationMonth": "00",
+                            "expirationYear": "0000",
+                            "productType": "PLATINUM",
+                            "productScheme": "VISA",
+                            "productCode": "ABCD1234",
+                            "cardName": "Regular",
+                            "cardMaterial": "plastic",
+                            "cardMaterialName": "plastic",
+                            "isPinActivated": true,
+                            "orderNumber": 542596,
+                            "orderDate": "2025-04-23T17:53:52.000Z",
+                            "cardHolder": {
+                              "id": "68c44898-a805-4d44-8c6d-3e9367343e96",
+                              "firstName": "Vest",
+                              "lastName": "QA"
+                            }
+                          }
+                        ],
+                        "total": 11,
+                        "totalPages": 3,
+                        "limit": "4"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Customer not found or no cards found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "customerNotFound": {
+                      "summary": "Customer not found",
+                      "value": {
+                        "message": "Customer not found"
+                      }
+                    },
+                    "noCardsFound": {
+                      "summary": "No cards found",
+                      "value": {
+                        "message": "No cards found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card": {
+        "post": {
+          "summary": "Create a card for a user",
+          "description": "Allows a Superadmin to create a card for a specific user.\nThe card details, such as usage frequency, amount limit can be specified in the request body.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user for whom the card is being created.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Card creation details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "The frequency of card usage",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "The amount limit for the card",
+                      "example": 1000
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Card created successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card created successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "cardActivated": {
+                      "summary": "Card created and activated",
+                      "value": {
+                        "message": "Card created successfully.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "active",
+                          "amount": 1000,
+                          "frequency": "per24HourPeriod",
+                          "last4Digits": "8377",
+                          "expirationMonth": "04",
+                          "expirationYear": "2030",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "ABCD1234",
+                          "isPinActivated": true,
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    },
+                    "cardNotActivated": {
+                      "summary": "Card created but not activated",
+                      "value": {
+                        "message": "Card created successfully but unable to activate.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "not_activated",
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Invalid fields in the request",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "status is required"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "amount is required"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          }
+                        ]
+                      }
+                    },
+                    "userAlreadyHasCard": {
+                      "summary": "User already has a card",
+                      "value": {
+                        "message": "Unable to save card because the user already has a card",
+                        "errors": [
+                          {
+                            "field": "userId",
+                            "message": "User already has a card"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User not found or not allowed to add cards",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User not found or not allowed to add cards"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card/{cardId}": {
+        "get": {
+          "summary": "Get card details for a user",
+          "description": "Retrieves the details of a specific card for a user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The ID of the card.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Card details retrieved successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details retrieved successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidCardId": {
+                      "summary": "Invalid card ID",
+                      "value": {
+                        "message": "Invalid card ID"
+                      }
+                    },
+                    "invalidUser": {
+                      "summary": "Invalid user",
+                      "value": {
+                        "message": "Invalid user"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update card details for a user",
+          "description": "Updates the details of a specific card for a user. The card details, such as usage frequency, amount limit, and status, can be specified in the request body.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to update for the card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "Usage frequency restrictions on the card.",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Maximum allowable limit for card transactions.",
+                      "example": 1000
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Updated status of the card.",
+                      "example": "active",
+                      "enum": [
+                        "notActivated",
+                        "active",
+                        "locked",
+                        "canceled"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully updated card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is invalid"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "summary": "Invalid frequency",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "frequency",
+                            "message": "Invalid card frequency"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "summary": "Invalid amount",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "amount",
+                            "message": "Invalid card amount"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample3": {
+                      "summary": "Invalid status",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "Invalid card status"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/user/{id}/card/{cardId}/secure": {
+        "get": {
+          "summary": "Get secure card details for a user",
+          "description": "Retrieves the secure details of a specific card for a user. This includes sensitive information that requires additional authorization.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The ID of the user.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "cardId",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "sessionid",
+              "in": "header",
+              "description": "Base64-encoded session ID of the user requesting the encrypted data",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Secure card details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "400": {
+              "description": "Unable to retrieve secure card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidCardId": {
+                      "summary": "Invalid card ID",
+                      "value": {
+                        "message": "Invalid card ID"
+                      }
+                    },
+                    "sessionExpired": {
+                      "summary": "Unable to retrieve secure card details",
+                      "value": {
+                        "message": "Session expired"
+                      }
+                    },
+                    "invalidUser": {
+                      "summary": "Invalid user",
+                      "value": {
+                        "message": "Invalid user"
+                      }
+                    },
+                    "invalidSession": {
+                      "summary": "Invalid session",
+                      "value": {
+                        "message": "Invalid session"
+                      }
+                    },
+                    "sessionIdNotFound": {
+                      "summary": "Session ID not found",
+                      "value": {
+                        "message": "Session ID not found in headers"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card": {
+        "get": {
+          "summary": "Fetch user cards",
+          "description": "Retrieve a list of all cards associated with the authenticated user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "The type of card to be fetched.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "physical"
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "description": "The status of card.",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "example": "active"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved the list of cards.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "List of cards retrieved successfully"
+                      },
+                      "cards": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "virtual"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Current status of the card",
+                              "example": "active",
+                              "enum": [
+                                "notActivated",
+                                "active",
+                                "locked",
+                                "canceled"
+                              ]
+                            },
+                            "last4Digits": {
+                              "type": "string",
+                              "example": "8377"
+                            },
+                            "expirationMonth": {
+                              "type": "string",
+                              "example": "4"
+                            },
+                            "expirationYear": {
+                              "type": "string",
+                              "example": "2030"
+                            },
+                            "productType": {
+                              "type": "string",
+                              "example": "PLATINUM",
+                              "enum": [
+                                "PLATINUM"
+                              ]
+                            },
+                            "productScheme": {
+                              "type": "string",
+                              "example": "VISA",
+                              "enum": [
+                                "VISA"
+                              ]
+                            },
+                            "productCode": {
+                              "type": "string",
+                              "example": "ABCD1234"
+                            },
+                            "cardName": {
+                              "type": "string",
+                              "example": "Regular"
+                            },
+                            "cardMaterial": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "cardMaterialName": {
+                              "type": "string",
+                              "example": "plastic"
+                            },
+                            "isPinActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "isActivated": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "example": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "example": "4561228"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "example": "Offer card"
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "example": "card",
+                                    "enum": [
+                                      "card"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "number",
+                                    "example": 0
+                                  },
+                                  "valueType": {
+                                    "type": "string",
+                                    "example": "amount",
+                                    "enum": [
+                                      "amount",
+                                      "percentage"
+                                    ]
+                                  },
+                                  "hasClaimed": {
+                                    "type": "boolean",
+                                    "example": false
+                                  },
+                                  "fees": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "example": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223"
+                                        },
+                                        "type": {
+                                          "type": "string",
+                                          "example": "activation",
+                                          "enum": [
+                                            "activation",
+                                            "rental"
+                                          ]
+                                        },
+                                        "label": {
+                                          "type": "string",
+                                          "example": "Card Fee"
+                                        },
+                                        "amount": {
+                                          "type": "number",
+                                          "example": 100
+                                        },
+                                        "interval": {
+                                          "type": "string",
+                                          "example": "lifetime"
+                                        },
+                                        "frequency": {
+                                          "type": "string",
+                                          "example": "one-time"
+                                        },
+                                        "coolOffPeriod": {
+                                          "type": "integer",
+                                          "example": 0
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "displayName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "orderNumber": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "orderDate": {
+                              "type": "Date",
+                              "example": "2025-04-23T17:53:52.000Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "physicalCard": {
+                      "summary": "Physical card details",
+                      "value": {
+                        "message": "Successfully retrieved user cards.",
+                        "cards": [
+                          {
+                            "id": "344fb823-9949-4401-829a-6e2c87825b10",
+                            "type": "physical",
+                            "status": "notActivated",
+                            "last4Digits": "9678",
+                            "expirationMonth": "01",
+                            "expirationYear": "2029",
+                            "productType": "SIGNATURE",
+                            "productScheme": "VISA",
+                            "productCode": "4578589k",
+                            "cardName": "Regular",
+                            "cardMaterial": "metal",
+                            "cardMaterialName": "Metal",
+                            "isPinActivated": false,
+                            "isActivated": false,
+                            "offers": [
+                              {
+                                "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                                "code": "4561228",
+                                "name": "Offer card",
+                                "type": "card",
+                                "value": 0,
+                                "valueType": "amount",
+                                "hasClaimed": false,
+                                "fees": [
+                                  {
+                                    "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 100,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  },
+                                  {
+                                    "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 500,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  }
+                                ]
+                              }
+                            ],
+                            "displayName": "asdasd",
+                            "orderNumber": "263729",
+                            "orderDate": "2025-04-30T13:05:00.000Z"
+                          }
+                        ]
+                      }
+                    },
+                    "virtualCard": {
+                      "summary": "Virtual card details",
+                      "value": {
+                        "message": "Successfully retrieved user cards.",
+                        "cards": [
+                          {
+                            "id": "45e88904-74b9-43b7-9e9b-ff16127078e1",
+                            "type": "virtual",
+                            "status": "active",
+                            "last4Digits": "2839",
+                            "expirationMonth": "03",
+                            "expirationYear": "2029",
+                            "productType": "PLATINUM",
+                            "productScheme": "VISA",
+                            "productCode": "82a7df4f",
+                            "cardName": "Neo Card",
+                            "isPinActivated": false,
+                            "isActivated": false,
+                            "offers": [
+                              {
+                                "id": "4e310251-f610-4ea2-9b91-8f1c05e7c3fe",
+                                "code": "4561228",
+                                "name": "Offer card",
+                                "type": "card",
+                                "value": 0,
+                                "valueType": "amount",
+                                "hasClaimed": false,
+                                "fees": [
+                                  {
+                                    "id": "8af29ee5-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 100,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  },
+                                  {
+                                    "id": "8af42440-f02e-11ef-a4ff-06d39f4fa223",
+                                    "type": "activation",
+                                    "label": "Card Fee",
+                                    "amount": 500,
+                                    "interval": "lifetime",
+                                    "frequency": "one-time",
+                                    "coolOffPeriod": 0
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The request is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid request payload."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "No cards found or user not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {}
+                  },
+                  "examples": {
+                    "noCards": {
+                      "summary": "No cards found",
+                      "value": {
+                        "message": "No cards found for the user"
+                      }
+                    },
+                    "userNotFound": {
+                      "summary": "User not found",
+                      "value": {
+                        "message": "User not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Add new card",
+          "description": "Add new card for the authenticated user with the provided details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to add a card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "coupon": {
+                      "type": "string",
+                      "example": "XYZ1234"
+                    },
+                    "fees": {
+                      "type": "array",
+                      "example": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "dispalyName": {
+                      "type": "string",
+                      "example": "John"
+                    },
+                    "cardMaterialCode": {
+                      "type": "string",
+                      "example": "ABCD1234"
+                    },
+                    "shipTo": {
+                      "type": "object",
+                      "properties": {
+                        "firstName": {
+                          "type": "string",
+                          "example": "John"
+                        },
+                        "lastName": {
+                          "type": "string",
+                          "example": "Doe"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "line2": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "city": {
+                          "type": "string",
+                          "example": "Mumbai"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "Maharashtra"
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "example": "400001"
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "example": "IN"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "India"
+                        },
+                        "phoneNumber": {
+                          "type": "string",
+                          "example": "9987454512"
+                        }
+                      }
+                    },
+                    "billTo": {
+                      "type": "object",
+                      "properties": {
+                        "line1": {
+                          "type": "string",
+                          "example": "456 Avenue Road"
+                        },
+                        "line2": {
+                          "type": "string",
+                          "example": "123 Street Name"
+                        },
+                        "city": {
+                          "type": "string",
+                          "example": "Delhi"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "Delhi"
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "example": "110001"
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "example": "IN"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "India"
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "virtualCard": {
+                    "summary": "Example request for virtual card",
+                    "value": {
+                      "code": "ABCD1234",
+                      "coupon": "XYZ1234",
+                      "fees": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d2"
+                      ]
+                    }
+                  },
+                  "physicalCard": {
+                    "summary": "Example request for physical card",
+                    "value": {
+                      "code": "ABCD1234",
+                      "coupon": "XYZ1234",
+                      "fees": [
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3",
+                        "114fe929-76e6-4fab-9de3-9a7d6ee9d3d3"
+                      ],
+                      "dispalyName": "Jane Doe",
+                      "cardMaterialCode": "MAT-PHY-01",
+                      "shipTo": {
+                        "firstname": "John",
+                        "lastName": "Doe",
+                        "line1": "789 Main Road",
+                        "line2": "Near Metro Station",
+                        "city": "Pune",
+                        "region": "Maharashtra",
+                        "postalCode": "411001",
+                        "countryCode": "IN",
+                        "country": "India",
+                        "phoneNumber": "9874561238"
+                      },
+                      "billTo": {
+                        "line1": "123 Office Lane",
+                        "line2": "Suite 21B",
+                        "city": "Bangalore",
+                        "region": "Karnataka",
+                        "postalCode": "560001",
+                        "countryCode": "IN",
+                        "country": "India"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully added a new card.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Successfully added a new card."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "firstName": {
+                                "type": "string"
+                              },
+                              "lastName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "virtualCard": {
+                      "summary": "Virtual card created successfully",
+                      "value": {
+                        "message": "Successfully added a new card.",
+                        "card": {
+                          "id": "c190c85b-f6a4-4681-9850-2ebc5cc5983a",
+                          "type": "virtual",
+                          "status": "active",
+                          "amount": 1000,
+                          "frequency": "per24HourPeriod",
+                          "last4Digits": "8377",
+                          "expirationMonth": "04",
+                          "expirationYear": "2030",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "ABCD1234",
+                          "isPinActivated": false,
+                          "cardHolder": {
+                            "id": "4712b721-924c-4e45-a078-e9dcbf28087d",
+                            "firstName": "SJ",
+                            "lastName": "J"
+                          }
+                        }
+                      }
+                    },
+                    "physicalCard": {
+                      "summary": "Physical card created successfully",
+                      "value": {
+                        "message": "Successfully added a new card.",
+                        "card": {
+                          "id": "b345a1ac-a403-4c3f-b334-5b3f676e3822",
+                          "type": "physical",
+                          "status": "notActivated",
+                          "amount": 0,
+                          "frequency": "per24HourPeriod",
+                          "productType": "PLATINUM",
+                          "productScheme": "VISA",
+                          "productCode": "PHYS5678",
+                          "cardMaterial": "plastic",
+                          "isPinActivated": false,
+                          "orderNumber": 1,
+                          "cardHolder": {
+                            "id": "b9123fa1-59e3-4e21-bd6a-9cf10dc12f44",
+                            "firstName": "Jane",
+                            "lastName": "Doe"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to add card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "code",
+                            "message": "Invalid Card Product Code"
+                          },
+                          {
+                            "field": "coupon",
+                            "message": "Invalid Coupon Code"
+                          }
+                        ]
+                      }
+                    },
+                    "FeeDetailValidationFailure": {
+                      "summary": "Fee detail validation failure",
+                      "value": {
+                        "message": "Unable to add card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "fees",
+                            "message": "Fee details are required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee ID(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3, 114fe929-76e6-4fab-9de3-9a7d6ee9d3d5) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Invalid fee(s):- (114fe929-76e6-4fab-9de3-9a7d6ee9d3d3) provided for the card product."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "activation type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Exactly one activation type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "rental type fee is required."
+                          },
+                          {
+                            "field": "fees",
+                            "message": "Exactly one rental type fee is required."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}": {
+        "get": {
+          "summary": "Retrieve card details",
+          "description": "Fetch detailed information about a specific card using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The unique identifier of the card.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Card details retrieved successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details retrieved successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "3f2dbbf9-8a60-4a5f-8ec0-b18acf7e2579"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "virtual"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Maximum allowable limit for card transactions.",
+                            "example": 1000
+                          },
+                          "frequency": {
+                            "type": "string",
+                            "description": "Usage frequency restrictions on the card.",
+                            "example": "per24HourPeriod",
+                            "enum": [
+                              "per24HourPeriod",
+                              "per7DayPeriod",
+                              "per30DayPeriod",
+                              "perYearPeriod",
+                              "allTime"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "8377"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "4"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2030"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productScheme": {
+                            "type": "string",
+                            "example": "VISA",
+                            "enum": [
+                              "VISA"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "ABCD1234"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "cardHolder": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "example": "68c44898-a805-4d44-8c6d-3e9367343e96"
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "example": "Vest"
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "example": "QA"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Modify card details",
+          "description": "Update specific details of a card, such as status or usage restrictions.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "The unique identifier of the card to be updated.",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Details to update for the card.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "description": "Usage frequency restrictions on the card.",
+                      "example": "per24HourPeriod",
+                      "enum": [
+                        "per24HourPeriod",
+                        "per7DayPeriod",
+                        "per30DayPeriod",
+                        "perYearPeriod",
+                        "allTime"
+                      ]
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Maximum allowable limit for card transactions.",
+                      "example": 1000
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Updated status of the card.",
+                      "example": "active",
+                      "enum": [
+                        "notActivated",
+                        "active",
+                        "locked",
+                        "canceled"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully updated card details.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card details updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save card because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "status",
+                            "message": "status is required"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "amount is required"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "Invalid card frequency"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "amount",
+                            "message": "Invalid card amount"
+                          },
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample3": {
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "frequency",
+                            "message": "frequency is required"
+                          },
+                          {
+                            "field": "status",
+                            "message": "Invalid card status"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/activate": {
+        "put": {
+          "summary": "Activate a card",
+          "description": "Mark a card as active using its unique identifier.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Required only for **physical cards** to verify last 4 digits and expiration details.\n\nFor **virtual cards**, the body should be omitted.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "last4Digits": {
+                      "type": "string",
+                      "description": "Last 4 digits of the physical card.",
+                      "example": "4710"
+                    },
+                    "expirationMonth": {
+                      "type": "string",
+                      "description": "Expiration month of the physical card.",
+                      "example": "10"
+                    },
+                    "expirationYear": {
+                      "type": "string",
+                      "description": "Expiration year of the physical card.",
+                      "example": "2029"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Amount ( in cents).",
+                      "example": 5000
+                    },
+                    "frequency": {
+                      "type": "string",
+                      "description": "frequency.",
+                      "example": "allTime"
+                    }
+                  }
+                }
+              }
+            },
+            "required": false
+          },
+          "responses": {
+            "200": {
+              "description": "Successfully activated the card.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Card activation successfully."
+                      },
+                      "card": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "e65a8911-9feb-44f7-86f8-64cc116d9e9b"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "physical"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "The updated status of the card.",
+                            "example": "active",
+                            "enum": [
+                              "notActivated",
+                              "active",
+                              "locked",
+                              "canceled"
+                            ]
+                          },
+                          "last4Digits": {
+                            "type": "string",
+                            "example": "6922"
+                          },
+                          "expirationMonth": {
+                            "type": "string",
+                            "example": "11"
+                          },
+                          "expirationYear": {
+                            "type": "string",
+                            "example": "2029"
+                          },
+                          "productType": {
+                            "type": "string",
+                            "example": "PLATINUM",
+                            "enum": [
+                              "PLATINUM"
+                            ]
+                          },
+                          "productCode": {
+                            "type": "string",
+                            "example": "4578589k"
+                          },
+                          "cardMaterial": {
+                            "type": "string",
+                            "example": "plastic"
+                          },
+                          "isPinActivated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "orderNumber": {
+                            "type": "number",
+                            "example": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided card ID is invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/{id}/secure": {
+        "get": {
+          "summary": "Retrieve secure card details",
+          "description": "Fetch encrypted card information using the card ID and session ID.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique identifier of the card",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            {
+              "name": "sessionid",
+              "in": "header",
+              "description": "Base64-encoded session ID of the user requesting the encrypted data",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Secure card details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid card ID",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid card ID"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/card/coupon": {
+        "get": {
+          "summary": "Validate coupon code",
+          "description": "Validate a coupon code to check if it is valid and can be applied to a card.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Card Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "description": "Partner code of this user.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "description": "Application code used for validating mobile-based requests.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            },
+            {
+              "name": "couponCode",
+              "in": "query",
+              "description": "The coupon code to be validated.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "ABCD1234"
+            },
+            {
+              "name": "productCode",
+              "in": "query",
+              "description": "The product code to be validated.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "PROD1234"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Coupon code is valid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Coupon code is valid"
+                      },
+                      "coupon": {
+                        "type": "object",
+                        "properties": {
+                          "discount": {
+                            "type": "number",
+                            "description": "Discount value to be applied to the card",
+                            "example": 100
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "Type of discount applied",
+                            "example": "flat",
+                            "enum": [
+                              "percentage",
+                              "flat"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Validation error.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "invalidProductCode": {
+                      "summary": "Invalid product code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "productCode",
+                            "message": "Invalid product code"
+                          }
+                        ]
+                      }
+                    },
+                    "invalidCouponCode": {
+                      "summary": "Invalid coupon code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "couponCode",
+                            "message": "Invalid coupon code."
+                          }
+                        ]
+                      }
+                    },
+                    "couponAlreadyUsed": {
+                      "summary": "Coupon code already used",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "couponCode",
+                            "message": "Coupon code already used."
+                          }
+                        ]
+                      }
+                    },
+                    "invalidUserEmail": {
+                      "summary": "Email not associated with coupon code",
+                      "value": {
+                        "message": "Validation error",
+                        "errors": [
+                          {
+                            "field": "userEmail",
+                            "message": "The user email does not registered."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/masterdata/{type}": {
+        "get": {
+          "summary": "Get master data by type",
+          "description": "Retrieve the list of master data by type. Supported types:\n  - **Country**: Returns a list of countries with codes and names.\n  - **DocumentType**: Returns document types available in the system.\n  - **DepositToken**: Returns a list of tokens associated with blockchains.\n  - **CardStatus**: Returns status information for various card types.\n  - **CardProduct**: Returns card product types available in the system.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Master Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "path",
+              "description": "Type of master data to retrieve (e.g., **Country**, **DepositToken**, **CardStatus**, **UserRole**, **CardProduct**, **Consent**).",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "Country",
+                  "DocumentType",
+                  "DepositToken",
+                  "CardStatus",
+                  "UserRole",
+                  "CardProduct",
+                  "Consent"
+                ]
+              }
+            },
+            {
+              "name": "keyType",
+              "in": "query",
+              "description": "Optional key type to filter the master data.",
+              "required": false,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List of master data by type",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "description": "Response when type is `Country`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "country_name": {
+                              "type": "string"
+                            },
+                            "country_code": {
+                              "type": "string"
+                            },
+                            "country_code_alpha3": {
+                              "type": "string"
+                            },
+                            "country_mobile_code": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `DocumentType`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "isActive": {
+                              "type": "boolean"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `DepositToken`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "chainId": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "logo": {
+                              "type": "string"
+                            },
+                            "tokens": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "symbol": {
+                                    "type": "string"
+                                  },
+                                  "address": {
+                                    "type": "string"
+                                  },
+                                  "logo": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `CardStatus`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "isActive": {
+                              "type": "boolean"
+                            },
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "description": "Response when type is `CardProduct`",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "scheme": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "fees": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "number"
+                                  },
+                                  "coolOffPeriod": {
+                                    "type": "number",
+                                    "description": "Number of days for cooling off period"
+                                  },
+                                  "frequency": {
+                                    "type": "string",
+                                    "description": "Frequency of the fee",
+                                    "enum": [
+                                      "one-time",
+                                      "recurring"
+                                    ]
+                                  },
+                                  "interval": {
+                                    "type": "string",
+                                    "description": "Interval of the fee",
+                                    "enum": [
+                                      "lifetime",
+                                      "monthly",
+                                      "yearly"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "cardMaterial": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "fees": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "number"
+                                      },
+                                      "coolOffPeriod": {
+                                        "type": "number"
+                                      },
+                                      "frequency": {
+                                        "type": "string",
+                                        "enum": [
+                                          "one-time",
+                                          "recurring"
+                                        ]
+                                      },
+                                      "interval": {
+                                        "type": "string",
+                                        "enum": [
+                                          "none",
+                                          "lifetime",
+                                          "monthly",
+                                          "yearly"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "examples": {
+                    "Country": {
+                      "summary": "Example response for Country type",
+                      "value": [
+                        {
+                          "country_name": "Dummyland",
+                          "country_code": "DL",
+                          "country_code_alpha3": "DUM",
+                          "country_mobile_code": "76"
+                        },
+                        {
+                          "country_name": "Testistan",
+                          "country_code": "TS",
+                          "country_code_alpha3": "TST",
+                          "country_mobile_code": "56"
+                        },
+                        {
+                          "country_name": "Mockland",
+                          "country_code": "ML",
+                          "country_code_alpha3": "MOK",
+                          "country_mobile_code": "35"
+                        }
+                      ]
+                    },
+                    "DocumentType": {
+                      "summary": "Example response for DocumentType",
+                      "value": [
+                        {
+                          "type": "DocumentType",
+                          "key": "MOCK_ID",
+                          "value": "Mock Identification",
+                          "isActive": true,
+                          "id": "11111111-1111-1111-1111-111111111111"
+                        },
+                        {
+                          "type": "DocumentType",
+                          "key": "TEST_DOC",
+                          "value": "Test Document",
+                          "isActive": true,
+                          "id": "22222222-2222-2222-2222-222222222222"
+                        },
+                        {
+                          "type": "DocumentType",
+                          "key": "DUMMY_CERT",
+                          "value": "Dummy Certificate",
+                          "isActive": false,
+                          "id": "33333333-3333-3333-3333-333333333333"
+                        }
+                      ]
+                    },
+                    "DepositToken": {
+                      "summary": "Example response for DepositToken",
+                      "value": [
+                        {
+                          "chainId": 99999,
+                          "name": "Test Chain Network",
+                          "logo": "https://example.com/test-chain.png",
+                          "tokens": [
+                            {
+                              "name": "Test Coin",
+                              "symbol": "TEST",
+                              "address": "0x1111111111111111111111111111111111111111",
+                              "logo": "https://example.com/test-coin.png"
+                            },
+                            {
+                              "name": "Mock Token",
+                              "symbol": "MOCK",
+                              "address": "0x2222222222222222222222222222222222222222",
+                              "logo": "https://example.com/mock-token.png"
+                            }
+                          ]
+                        },
+                        {
+                          "chainId": 88888,
+                          "name": "Mock Chain Network",
+                          "logo": "https://example.com/mock-chain.png",
+                          "tokens": [
+                            {
+                              "name": "Dummy Coin",
+                              "symbol": "DUMMY",
+                              "address": "0x3333333333333333333333333333333333333333",
+                              "logo": "https://example.com/dummy-coin.png"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "CardStatus": {
+                      "summary": "Example response for CardStatus",
+                      "value": [
+                        {
+                          "type": "CardStatus",
+                          "key": "test_status",
+                          "value": "Test Status",
+                          "isActive": true,
+                          "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                        },
+                        {
+                          "type": "CardStatus",
+                          "key": "mock_status",
+                          "value": "Mock Status",
+                          "isActive": true,
+                          "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                        },
+                        {
+                          "type": "CardStatus",
+                          "key": "dummy_status",
+                          "value": "Dummy Status",
+                          "isActive": false,
+                          "id": "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                        }
+                      ]
+                    },
+                    "CardProductType": {
+                      "summary": "Example response for Card Product",
+                      "value": [
+                        {
+                          "type": "PLATINUM",
+                          "scheme": "VISA",
+                          "code": "ABCD1234",
+                          "label": "Platinum Rewards Card",
+                          "description": "Earn 2x points on every purchase",
+                          "fees": [
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                              "type": "activation",
+                              "label": "Joining Fees",
+                              "amount": 49900,
+                              "coolOffPeriod": 30,
+                              "frequency": "one-time",
+                              "interval": "lifetime"
+                            },
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                              "type": "rental",
+                              "label": "Monthly Fees",
+                              "amount": 25900,
+                              "coolOffPeriod": 31,
+                              "frequency": "recurring",
+                              "interval": "monthly"
+                            },
+                            {
+                              "id": "114fe929-76e6-4fab-9de3-9b7d6ee9c3d3",
+                              "type": "rental",
+                              "label": "Yearly Fees",
+                              "amount": 99900,
+                              "coolOffPeriod": 31,
+                              "frequency": "recurring",
+                              "interval": "yearly"
+                            }
+                          ],
+                          "cardMaterial": [
+                            {
+                              "code": "metal",
+                              "name": "Metal",
+                              "fees": {
+                                "id": "79e9a063-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            },
+                            {
+                              "code": "semi-metal",
+                              "name": "Semi-metal",
+                              "fees": {
+                                "id": "c0566eee-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            },
+                            {
+                              "code": "plastic",
+                              "name": "Plastic",
+                              "fees": {
+                                "id": "78a54dc0-2101-11f0-99a4-0242ac110005",
+                                "type": "activation",
+                                "label": "Premium Metal Card Fee",
+                                "amount": 250,
+                                "coolOffPeriod": 0,
+                                "frequency": "one-time",
+                                "interval": "lifetime"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "Consent": {
+                      "summary": "Example response for Consent",
+                      "value": [
+                        {
+                          "id": "3c9faeb4-30fc-4bbf-8890-e8beec565407",
+                          "type": "signup",
+                          "message": "I accept the Consent",
+                          "isMandatory": true,
+                          "isActive": true
+                        },
+                        {
+                          "id": "8217bf6b-bc1c-4272-864f-bc721e3d1771",
+                          "type": "signup",
+                          "message": "I certify that the information.",
+                          "isMandatory": true,
+                          "isActive": true
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request - Invalid master data type",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Invalid master data type"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/masterdata/occupation": {
+        "get": {
+          "summary": "Get consumer occupations or corporate industry",
+          "description": "Retrieve a list of consumer occupations or corporate industry.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Master Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "description": "Partner code associated with the request.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89DE4F"
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "description": "Application code for validating mobile requests.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK - A list of matching consumer occupations.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "Represents a consumer occupation entry.",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "description": "Unique code identifier for the occupation.",
+                          "example": "11-3011"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the occupation.",
+                          "example": "Administrative Services Managers"
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                          "description": "Indicates if the occupation record is currently active.",
+                          "example": true
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "name",
+                        "isActive"
+                      ]
+                    }
+                  },
+                  "example": [
+                    {
+                      "code": "11-3011",
+                      "name": "Administrative Services Managers",
+                      "isActive\"": true
+                    },
+                    {
+                      "code": "11-2011",
+                      "name": "Advertising and Promotions Managers",
+                      "isActive": true
+                    },
+                    {
+                      "code": "13-1011",
+                      "name": "Agents and Business Managers of Artists, Performer",
+                      "isActive": true
+                    }
+                  ]
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/deposit": {
+        "get": {
+          "summary": "Retrieve deposit information for the customer",
+          "description": "This API returns deposit details for the authenticated customer.\n- Returns deposits made under the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Deposit information retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chainId": {
+                          "type": "number"
+                        },
+                        "proxyAddress": {
+                          "type": "string"
+                        },
+                        "proxyAddressQrCode": {
+                          "type": "string",
+                          "description": "QR code image data for proxyAddress",
+                          "example": "data:image/png;base64,iVBORw0..."
+                        },
+                        "tokens": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Deposit information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Deposit information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/balance": {
+        "get": {
+          "summary": "Retrieve wallet balance for the customer",
+          "description": "This API returns the current wallet balance for the authenticated customer. The response includes:\n  - Returns the balance for the customer account.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Wallet balance retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "balanceDue": {
+                        "type": "number"
+                      },
+                      "creditLimit": {
+                        "type": "number"
+                      },
+                      "pendingCharges": {
+                        "type": "number"
+                      },
+                      "postedCharges": {
+                        "type": "number"
+                      },
+                      "spendingPower": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Balance information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Balance information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/withdrawal": {
+        "get": {
+          "summary": "Retrieve withdrawal detail for the customer",
+          "description": "This API returns the current withdrawal detail for the authenticated customer. The response includes:\n  - Controller address\n  - Withdrawal fee\n  - Balance information based on available token address\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "chainId",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Chain Id for getting the withdrawal detail",
+                "example": 84532
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Withdrawal details retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "controllerAddress": {
+                        "type": "string",
+                        "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                      },
+                      "controllerContractAbi": {
+                        "type": "array",
+                        "example": []
+                      },
+                      "fees": {
+                        "type": "number",
+                        "description": "Withdrawal fee in cents",
+                        "example": 100
+                      },
+                      "bundlerUrl": {
+                        "type": "string",
+                        "example": "https://bundler.biconomy.io/api/v3/98765/xYzAbC9de.123a456b-78cd-90ef-12gh-345ijklm6789"
+                      },
+                      "paymasterUrl": {
+                        "type": "string",
+                        "example": "https://paymaster.biconomy.io/api/v2/98765/gH2klmNpQ.1a2b3c4d-5e6f-7890-gh12-ijk34lm56789"
+                      },
+                      "tokens": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "example": "0x67AC51b706b7f34cA7D966203aD904bE85762623"
+                            },
+                            "balance": {
+                              "type": "number",
+                              "example": 50
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "ChainId is Invalid",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "chainId"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "chainId is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get withdrawal detail because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "chainId",
+                            "message": "Invalid chainId"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Withdrawal information not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Balance information not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "To generate withdrawal signature",
+          "description": "This API allows the authenticated customer for generating a withdrawal signature using chainId, token, amount and recipient address.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "chainId": {
+                      "type": "integer",
+                      "description": "The chain ID where the smart contract is deployed.",
+                      "example": 1
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "The address of the token to withdraw, as a hex string.",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "amount": {
+                      "type": "integer",
+                      "description": "The amount of the token to withdraw.",
+                      "example": 100
+                    },
+                    "recipientAddress": {
+                      "type": "string",
+                      "description": "The address to which the withdrawal should be sent, as a hex string.",
+                      "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Withdrawal signature retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "example": "Withdrawal signature retrieved successfully"
+                          },
+                          "withdrawalId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "996a751b-c47f-45c3-98f4-04afa9ce9a80"
+                          },
+                          "status": {
+                            "type": "string",
+                            "example": "Success"
+                          },
+                          "retryCount": {
+                            "type": "integer",
+                            "example": 0
+                          },
+                          "signature": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "string",
+                                "example": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c"
+                              },
+                              "salt": {
+                                "type": "string",
+                                "example": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                              }
+                            }
+                          },
+                          "expiresAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2025-01-31T04:52:45.000Z"
+                          },
+                          "senders": {
+                            "type": "string",
+                            "example": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931"
+                          },
+                          "parameters": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "example": "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F"
+                                },
+                                {
+                                  "type": "integer",
+                                  "example": 2410000
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer",
+                                    "example": [
+                                      57,
+                                      154,
+                                      15,
+                                      14,
+                                      48,
+                                      237,
+                                      226,
+                                      36,
+                                      148,
+                                      245,
+                                      242,
+                                      152,
+                                      252,
+                                      31,
+                                      203,
+                                      51,
+                                      88,
+                                      107,
+                                      251,
+                                      170,
+                                      118,
+                                      162,
+                                      229,
+                                      236,
+                                      51,
+                                      56,
+                                      254,
+                                      18,
+                                      26,
+                                      46,
+                                      81,
+                                      126
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "examples": {
+                    "signatureReady": {
+                      "summary": "Signature Ready",
+                      "value": {
+                        "message": "Withdrawal signature retrieved successfully",
+                        "withdrawalId": "996a751b-c47f-45c3-98f4-04afa9ce9a80",
+                        "status": "Success",
+                        "retryCount": 0,
+                        "signature": {
+                          "data": "0xbaeb1d79534132929c475223cd67fa0cf9c7f634fbd872a48b8031009b56727b3b3c70e0a94acefa5ccf76354afba79c7f16319f023e640d55725e51df43300c1c",
+                          "salt": "OZoPDjDt4iSU9fKY/B/LM1hr+6p2ouXsMzj+EhouUX4="
+                        },
+                        "expiresAt": "2025-01-31T04:52:45.000Z",
+                        "senders": "0x53c960C2979Ff6254A50fDA7e53236413dA1E931",
+                        "parameters": [
+                          "0x47A384a5D7EFBE2C387c2abb138A397BbD041D2F",
+                          "0x29684075a3C86ea11D9964BcAf0F956e801396bD",
+                          2410000,
+                          "0x67AC51b706b7f34cA7D966203aD904bE85762623",
+                          1738299165,
+                          [
+                            57,
+                            154,
+                            15,
+                            14,
+                            48,
+                            237,
+                            226,
+                            36,
+                            148,
+                            245,
+                            242,
+                            152,
+                            252,
+                            31,
+                            203,
+                            51,
+                            88,
+                            107,
+                            251,
+                            170,
+                            118,
+                            162,
+                            229,
+                            236,
+                            51,
+                            56,
+                            254,
+                            18,
+                            26,
+                            46,
+                            81,
+                            126
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get signature because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "chain Id",
+                            "message": "Invalid Chain Id"
+                          },
+                          {
+                            "field": "admin adress ",
+                            "message": "Invalid Admin Address"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "Invalid Amount"
+                          },
+                          {
+                            "field": "amount",
+                            "message": "Invalid Withdrawal Amount, it must be a positive integer"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "406": {
+              "description": "Signature Generation failed.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Failed to generate signature. Please try again after 5 minutes. If any funds were deducted, don’t worry—they will be credited back within this time."
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "429": {
+              "description": "Too Many Requests.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Your signature request is still being processed. Please try again after 5 minute(s). If any funds were deducted, don’t worry—they will be credited back within this time."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/withdrawal/{id}": {
+        "put": {
+          "summary": "Update withdrawal status",
+          "description": "This API updates the status of the signature usage for a withdrawal request.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique identifier for the withdrawal request.",
+                "example": "a12345b6-78c9-0123-d456-789e012f34gh"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "New status of the withdrawal request.",
+                      "example": "success"
+                    },
+                    "txhash": {
+                      "type": "string",
+                      "description": "(Optional) Transaction hash if available.",
+                      "example": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Withdrawal status updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Withdrawal status updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "status"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "status is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to get signature because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "Withdrawal Id",
+                            "message": "Invalid Withdrawal Id"
+                          },
+                          {
+                            "field": "Token ",
+                            "message": "Invalid token"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Withdrawal request not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Withdrawal with request ID 123 not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Internal Server Error: Unable to update withdrawal status."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/wallet/owner": {
+        "get": {
+          "summary": "Retrieve wallet address update status for the authenticated user",
+          "description": "This API retrieves the wallet status of the authenticated user.\n- Checks if the wallet address has been updated.\n- Identifies if the user is the wallet owner.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user is associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "User wallet status retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User wallet status retrieved successfully"
+                      },
+                      "data": {
+                        "type": "object",
+                        "properties": {
+                          "isWalletUpdated": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "isWalletOwner": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "User not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "User not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "put": {
+          "summary": "Update wallet address for authenticated user",
+          "description": "Updates the wallet address. Once updated, further updates are restricted.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Wallet"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string",
+                      "description": "New wallet address for the user.",
+                      "example": "0xabcdefabcdefabcdefabcdefabcdefabcdef"
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Wallet address updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Wallet address updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The provided details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "address"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Address is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailure": {
+                      "summary": "Validation failure",
+                      "value": {
+                        "message": "Unable to update wallet address due to validation failures",
+                        "errors": [
+                          {
+                            "field": "address",
+                            "message": "Address is required"
+                          },
+                          {
+                            "field": "x-partner-code",
+                            "message": "Invalid partner code"
+                          },
+                          {
+                            "field": "x-app-code",
+                            "message": "Invalid app code"
+                          },
+                          {
+                            "field": "walletAddress",
+                            "message": "Wallet Address must be valid"
+                          }
+                        ]
+                      }
+                    },
+                    "walletAlreadyUpdated": {
+                      "summary": "Wallet Address Already Updated",
+                      "value": {
+                        "message": "Wallet Address already updated"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal server error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Internal Server Error: Unable to update wallet address."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/transaction": {
+        "get": {
+          "summary": "Get transactions",
+          "description": "This API returns transaction details. \n- Returns transaction details.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Transactions"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "Page number",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Number of items per page",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "description": "Sort field",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "date",
+                  "amount"
+                ]
+              }
+            },
+            {
+              "name": "sortDirection",
+              "in": "query",
+              "description": "Sort direction",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Transaction type",
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "spend",
+                  "deposit",
+                  "refund"
+                ]
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "description": "Transaction status",
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "merchantName",
+              "in": "query",
+              "description": "Merchant name",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Transactions fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "67a21ce9971b27fea38169e3"
+                            },
+                            "type": {
+                              "type": "string",
+                              "example": "spend"
+                            },
+                            "status": {
+                              "type": "string",
+                              "example": "completed"
+                            },
+                            "merchantName": {
+                              "type": "string",
+                              "example": "zomoto"
+                            },
+                            "date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-02-04T04:59:17.272Z"
+                            },
+                            "amount": {
+                              "type": "number",
+                              "example": 100
+                            },
+                            "currency": {
+                              "type": "string",
+                              "example": "usd"
+                            },
+                            "localAmount": {
+                              "type": "number",
+                              "example": 100
+                            },
+                            "localCurrency": {
+                              "type": "string",
+                              "example": "usd"
+                            }
+                          }
+                        }
+                      },
+                      "totalTransactions": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalSpent": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "totalReceived": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "totalBalance": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "page": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "totalPages": {
+                        "type": "integer",
+                        "example": 1
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/transaction/{id}": {
+        "get": {
+          "summary": "Get transaction detail",
+          "description": "Fetches details of a specific transaction.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Transactions"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Unique identifier of the transaction.",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "example": "17389431-9fb7-4689-a15b-c799f5cacb63"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Transaction fetched successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Transaction fetched successfully."
+                      },
+                      "id": {
+                        "type": "string",
+                        "example": "173894319fb74689"
+                      },
+                      "from": {
+                        "type": "string",
+                        "example": "Abcd"
+                      },
+                      "card": {
+                        "type": "string",
+                        "example": "1234"
+                      },
+                      "type": {
+                        "type": "string",
+                        "example": "spend"
+                      },
+                      "status": {
+                        "type": "string",
+                        "example": "completed"
+                      },
+                      "to": {
+                        "type": "string",
+                        "example": "test"
+                      },
+                      "date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2024-12-14T04:54:57.326Z"
+                      },
+                      "amount": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "currency": {
+                        "type": "string",
+                        "example": "usd"
+                      },
+                      "localAmount": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "localCurrency": {
+                        "type": "string",
+                        "example": "usd"
+                      },
+                      "transactionHash": {
+                        "type": "string",
+                        "example": "0x15189e46823bb"
+                      },
+                      "depositAddress": {
+                        "type": "string",
+                        "example": "0x15189e46823bb"
+                      },
+                      "chain": {
+                        "type": "string",
+                        "example": "Polygon (137)"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "spendTransaction": {
+                      "summary": "Transaction Spent",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "Abcd",
+                        "card": "1234",
+                        "type": "spend",
+                        "status": "completed",
+                        "to": "test",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "localAmount": 100,
+                        "localCurrency": "usd"
+                      }
+                    },
+                    "refundTransaction": {
+                      "summary": "Transaction Refund",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "test",
+                        "card": "1234",
+                        "type": "refund",
+                        "status": "completed",
+                        "to": "Abcd",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "localAmount": 100,
+                        "localCurrency": "usd"
+                      }
+                    },
+                    "depositTransaction": {
+                      "summary": "Transaction Deposit",
+                      "value": {
+                        "message": "Transaction fetched successfully.",
+                        "id": "173894319fb74689",
+                        "from": "0x15189e46823bb",
+                        "to": "On-Chain",
+                        "type": "deposit",
+                        "depositAddress": "0x15189e46823bb",
+                        "chain": "Polygon (137)",
+                        "status": "completed",
+                        "date": "2024-12-14T04:54:57.326Z",
+                        "amount": 100,
+                        "currency": "usd",
+                        "transactionHash": "0x15189e46823bb"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Transaction detail not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Transaction detail not found."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/notification": {
+        "get": {
+          "summary": "Get notifications",
+          "description": "Retrieve the list of notifications for the user.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Notification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved notifications",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "notifications": {
+                        "type": "array",
+                        "description": "List of user notifications",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Your profile has been updated."
+                            },
+                            "date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2024-10-11T12:00:00Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while fetching notifications."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Unable to retrieve notifications"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while fetching notifications.",
+                    "error": "Unable to retrieve notifications"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/notification/{id}": {
+        "put": {
+          "summary": "Update notification",
+          "description": "Update the read status of a notification.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Notification"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the notification to update",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "read": {
+                      "type": "boolean",
+                      "description": "Whether the notification is read or not",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Notification updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Notification updated successfully."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Description of the error that occurred",
+                        "example": "Error occurred while fetching notifications."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Detailed error information (optional)",
+                        "example": "Unable to retrieve notifications"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Error occurred while updating notification.",
+                    "error": "Notification not found"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/account": {
+        "get": {
+          "summary": "Fetch Referral code and referral count",
+          "description": "Retreive referral code and number of reffered customers\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Account Information fetched Succesfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Referral Data retreived succesfully."
+                      },
+                      "badge": {
+                        "type": "object",
+                        "description": "Badge earned by the user based on their activities in the system.",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "description": "Short code for the badge.",
+                            "example": "SupF"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Full name of the badge.",
+                            "example": "SuperFan"
+                          }
+                        }
+                      },
+                      "referralCode": {
+                        "type": "string",
+                        "example": "absdkfjhika"
+                      },
+                      "referralDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.1
+                      },
+                      "referralDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "percentage",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "referralCount": {
+                        "type": "number",
+                        "example": 62
+                      },
+                      "referralEarning": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "referrerCode": {
+                        "type": "string",
+                        "example": "absdkfjhdsd"
+                      },
+                      "referrerDiscount": {
+                        "type": "number",
+                        "description": "Discount value for the referral.",
+                        "example": 0.2
+                      },
+                      "referrerDiscountType": {
+                        "type": "string",
+                        "description": "Type of discount applied",
+                        "example": "flat",
+                        "enum": [
+                          "percentage",
+                          "flat"
+                        ]
+                      },
+                      "totalEarning": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "totalClaimed": {
+                        "type": "number",
+                        "example": 0
+                      },
+                      "minClaimAmount": {
+                        "type": "number",
+                        "description": "In cents",
+                        "example": 50
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/account/reward/claim": {
+        "get": {
+          "summary": "Fetch all pending reward claim requests",
+          "description": "Retrieves all reward claim requests that are currently pending.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "page",
+              "in": "query",
+              "description": "Page number",
+              "schema": {
+                "type": "integer",
+                "default": 1
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Number of items per page",
+              "schema": {
+                "type": "integer",
+                "default": 10
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successfully retrieved all pending reward claims.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Claims retrieved successfully"
+                      },
+                      "claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 123456789
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Claim status (pending, completed).",
+                              "example": "pending"
+                            },
+                            "amount": {
+                              "type": "number",
+                              "example": 211.45
+                            },
+                            "txhash": {
+                              "type": "string",
+                              "description": "Transaction hash of the completed claim request.",
+                              "example": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb"
+                            },
+                            "createdAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-02-04T04:59:17.272Z"
+                            }
+                          }
+                        }
+                      },
+                      "totalClaims": {
+                        "type": "number",
+                        "example": 100
+                      },
+                      "totalPages": {
+                        "type": "number",
+                        "example": 10
+                      },
+                      "page": {
+                        "type": "number",
+                        "example": 2
+                      },
+                      "limit": {
+                        "type": "number",
+                        "example": 10
+                      }
+                    }
+                  },
+                  "examples": {
+                    "PendingClaim": {
+                      "summary": "Example of a pending claim",
+                      "value": {
+                        "status": "success",
+                        "message": "Claims retrieved successfully",
+                        "claims": [
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                            "status": "pending",
+                            "amount": 211.45,
+                            "txhash": "",
+                            "createdAt": "2025-02-27T11:50:40.000Z"
+                          }
+                        ],
+                        "totalClaims": 100,
+                        "totalPages": 10,
+                        "page": 2,
+                        "limit": 10
+                      }
+                    },
+                    "CompletedClaim": {
+                      "summary": "Example of a completed claim",
+                      "value": {
+                        "status": "success",
+                        "message": "Claims retrieved successfully",
+                        "claims": [
+                          {
+                            "id": "114fe929-76e6-4fab-9de3-9b7d6ee9d3d3",
+                            "status": "completed",
+                            "amount": 211.45,
+                            "txhash": "0x4e9adb4702bcb3982222e9c1dbdae702caf98c363840bdd4dfde084459a8b0eb",
+                            "createdAt": "2025-02-27T11:50:40.000Z"
+                          }
+                        ],
+                        "totalClaims": 100,
+                        "totalPages": 10,
+                        "page": 2,
+                        "limit": 10
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Raise a reward claim request",
+          "description": "Stores the data in the database indicating that the user's request for reward claim has been raised.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner associated with the user.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "Account Summary"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Request for reward claim has been raised successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string",
+                        "example": "success"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "Your reward claim request has been raised."
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/version": {
+        "get": {
+          "summary": "Check App Version",
+          "description": "Endpoint to check if mobile app version requires update\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "currentVersion",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Current version of the mobile application",
+                "example": "1.2.3"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Version check completed successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "latestVersion": {
+                        "type": "string",
+                        "description": "Latest available version of the app",
+                        "example": "2.0.0"
+                      },
+                      "forceUpdate": {
+                        "type": "boolean",
+                        "description": "Whether user must update before continuing",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Validation failed"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "missingVersion": {
+                      "summary": "Missing version",
+                      "value": {
+                        "message": "Current version is missing",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Current version must be provided."
+                          }
+                        ]
+                      }
+                    },
+                    "invalidFormat": {
+                      "summary": "Invalid version format",
+                      "value": {
+                        "message": "Invalid version format",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
+                          }
+                        ]
+                      }
+                    },
+                    "futureVersion": {
+                      "summary": "Version cannot be greater than the latest version",
+                      "value": {
+                        "message": "Invalid version",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Current version cannot be greater than the latest version."
+                          }
+                        ]
+                      }
+                    },
+                    "majorVersionMismatch": {
+                      "summary": "Multiple version updates pending",
+                      "value": {
+                        "message": "Multiple version updates required",
+                        "errors": [
+                          {
+                            "field": "currentVersion",
+                            "message": "Your app version (1.2.0) is more than one version behind the latest version."
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/consent": {
+        "get": {
+          "summary": "Retrieve the User Consent details",
+          "description": "This API returns the Consent information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Consent details fetched successfully.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Response message",
+                        "example": "Consent Fetched Successfully"
+                      },
+                      "consent": {
+                        "type": "array",
+                        "description": "List of consents",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "Unique identifier for the consent",
+                              "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "Type of consent (e.g., signup)",
+                              "example": "signup"
+                            },
+                            "accepted": {
+                              "type": "boolean",
+                              "description": "Whether the user accepted the consent",
+                              "example": false
+                            },
+                            "isMandatory": {
+                              "type": "boolean",
+                              "description": "Whether the consent is mandatory",
+                              "example": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        },
+        "post": {
+          "summary": "Update the User Consent details",
+          "description": "This API Updates the Consent information of the user and returns the updated consent.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "List of consent acceptance details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the consent",
+                        "example": "e980ac8f-49e0-4fbf-b24b-d9be449671a4"
+                      },
+                      "accepted": {
+                        "type": "boolean",
+                        "description": "Whether the user accepted the consent",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Consent Fetched Succesfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Consent Updated succesfully",
+                        "example": "Consent Updated succesfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "The consent details are invalid.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unable to save consent because of the validation failures"
+                      },
+                      "errors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "consent"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Consent is required"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "examples": {
+                    "validationFailureSample1": {
+                      "summary": "Missing consent",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "consent",
+                            "message": "Consent id required"
+                          }
+                        ]
+                      }
+                    },
+                    "validationFailureSample2": {
+                      "summary": "Invalid consent type",
+                      "value": {
+                        "message": "Unable to save card because of the validation failures",
+                        "errors": [
+                          {
+                            "field": "consentId",
+                            "message": "ConsentId should be of string type"
+                          },
+                          {
+                            "field": "accepted",
+                            "message": "accepted should be of boolean type"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      },
+      "/app/consent/status": {
+        "get": {
+          "summary": "Retrieve the User Consent Status",
+          "description": "This API returns the Consent Status information of the user.\n- Returns information related to the user consent.\n\n**Headers**:\n- **x-partner-code**: Identifies the partner to whom the user and customer are associated.\n- **x-app-code**: Used for authentication to validate mobile-based requests.\n",
+          "tags": [
+            "App Management"
+          ],
+          "parameters": [
+            {
+              "name": "x-partner-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Partner code of this user.",
+                "example": "AB89DE4F"
+              }
+            },
+            {
+              "name": "x-app-code",
+              "in": "header",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Application code used for validating mobile-based requests.",
+                "example": "AB89Dasdasdasdaddasdasd9a8d9sdas9d878s7dE4F"
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Consent Status Fetched Succesfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "description": "Consent fetched succesfully",
+                        "example": "Consent Status fetched succesfully"
+                      },
+                      "consentStatus": {
+                        "type": "boolean",
+                        "description": "The consent status",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Access is denied due to invalid or missing token.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Unauthorized access. Token is missing or invalid."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Invalid or expired token"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "An unexpected error occurred on the server.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Something went wrong on the server. Please try again later."
+                      },
+                      "error": {
+                        "type": "string",
+                        "example": "Internal Server Error"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "SignInEmailRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's email address",
+              "example": "user@example.com"
+            },
+            "password": {
+              "type": "string",
+              "description": "The user's password",
+              "example": "password123"
+            }
+          },
+          "required": [
+            "email",
+            "password"
+          ]
+        },
+        "SignInResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Successfully authenticated."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            },
+            "token2fa": {
+              "type": "string",
+              "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+              "example": "U2FsdGVkX1...",
+              "nullable": true
+            }
+          }
+        },
+        "SignInSocialResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Successfully authenticated."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            },
+            "token2fa": {
+              "type": "string",
+              "description": "Temporary 2FA token returned if 2FA is enabled (used to verify 2FA with OTP)",
+              "example": "U2FsdGVkX1...",
+              "nullable": true
+            }
+          }
+        },
+        "SignInEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid credentials"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignInSocialRequest": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "The social provider used for signing in (e.g., google, facebook)",
+              "example": "google"
+            },
+            "token": {
+              "type": "string",
+              "description": "The OAuth token from the social provider",
+              "example": "eyJhbGciOiJIUzI1..."
+            }
+          },
+          "required": [
+            "provider",
+            "token"
+          ]
+        },
+        "SignInSocialErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid social token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignOutErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while signing out"
+            }
+          }
+        },
+        "SignInMobileRequest": {
+          "type": "object",
+          "properties": {
+            "authToken": {
+              "type": "string",
+              "description": "The permanent mobile verification code issued after successful mobile verification via the **verify-otp** API.",
+              "example": "eyJhbGciOiJIUzI1..."
+            }
+          },
+          "required": [
+            "authToken"
+          ]
+        },
+        "SignInMobileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid verification code"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Authentication failed"
+            }
+          }
+        },
+        "SignUpEmailRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's email address",
+              "example": "user@example.com"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The user's first name",
+              "example": "John"
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The user's last name",
+              "example": "Doe"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        },
+        "SignUpEmailResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "User registered successfully. Please verify your email."
+            }
+          }
+        },
+        "SignUpEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error",
+              "example": "A descriptive error message"
+            },
+            "error": {
+              "type": "string",
+              "description": "Optional detailed error information (only for server errors)",
+              "example": "Detailed error information"
+            }
+          }
+        },
+        "VerifyEmailResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message indicating the email has been verified.",
+              "example": "Email verified successfully. Please create your password."
+            },
+            "accessToken": {
+              "type": "string",
+              "description": "Short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "Long-lived refresh token (used to refresh the access token)",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          }
+        },
+        "VerifyEmailErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Error message if the token is invalid or expired",
+              "example": "Invalid or expired token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information",
+              "example": "Verification failed"
+            }
+          }
+        },
+        "RefreshTokenRequest": {
+          "type": "object",
+          "properties": {
+            "refreshToken": {
+              "type": "string",
+              "description": "The refresh token provided during sign-in *",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          },
+          "required": [
+            "refreshToken"
+          ]
+        },
+        "RefreshTokenResponse": {
+          "type": "object",
+          "properties": {
+            "accessToken": {
+              "type": "string",
+              "description": "New short-lived JWT token for authentication (typically expires in 15 minutes)",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            },
+            "refreshToken": {
+              "type": "string",
+              "description": "(Optional) A new refresh token, if a new one is issued",
+              "example": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+            }
+          }
+        },
+        "RefreshTokenErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Invalid refresh token"
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information",
+              "example": "Refresh token expired or invalid"
+            }
+          }
+        },
+        "CaptchaInitResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha challenge initialized successfully."
+            },
+            "status": {
+              "type": "string",
+              "example": "success"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "lot_number": {
+                  "type": "string",
+                  "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+                },
+                "captcha_type": {
+                  "type": "string",
+                  "example": "slide"
+                },
+                "captcha_output": {
+                  "type": "string",
+                  "example": "AgFD8gWUUuHFx-XvpP7J2VmYC4F_8xsMv6UMT3_Tx4RQWvgd5p..."
+                },
+                "pass_token": {
+                  "type": "string",
+                  "example": "eb45d40f85654d7f4cea4b384c9292f0286a5249d7fe5c038dcc3328e5b75a3d"
+                },
+                "captcha_id": {
+                  "type": "string",
+                  "example": "fb362ff464a632747b0dd0ea90bab013"
+                }
+              }
+            }
+          }
+        },
+        "CaptchaValidationRequest": {
+          "type": "object",
+          "properties": {
+            "mobile": {
+              "type": "string",
+              "example": "9456262167"
+            },
+            "captcha_id": {
+              "type": "string",
+              "example": "d81db9ghjk82bc8abb8b93a6b24b"
+            },
+            "lot_number": {
+              "type": "string",
+              "example": "362ff4642747b0dd0ea90bab013ss"
+            },
+            "captcha_output": {
+              "type": "string",
+              "example": "T36iviaxIxKnYfg-cP66mmU3Hew-rq_fzONutVS3mzv2I3I0o9BiXVtJFJssdLAmRNToLarOSGhr4rGpqn"
+            },
+            "pass_token": {
+              "type": "string",
+              "example": "153be1b6b7ccb121dab6401950409d9ca6f6a7915ed010ce04303fedd03"
+            },
+            "gen_time": {
+              "type": "string",
+              "example": "1747751473"
+            }
+          },
+          "required": [
+            "mobile",
+            "captcha_id",
+            "lot_number",
+            "captcha_output",
+            "pass_token",
+            "gen_time"
+          ]
+        },
+        "CaptchaValidationResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha validated successfully."
+            },
+            "accessToken": {
+              "type": "string",
+              "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.VC_NXTJ9zAUp5QXnMwWqY0dx5yYjwCsp4bgflm5k76Y"
+            }
+          }
+        },
+        "CaptchaValidationErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Captcha validation failed."
+            },
+            "error": {
+              "type": "string",
+              "example": "pass_token expire"
+            }
+          }
+        },
+        "Generate2FASecretResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message",
+              "example": "2FA secret generated successfully."
+            },
+            "qrCodeData": {
+              "type": "string",
+              "description": "QR code image data for scanning",
+              "example": "data:image/png;base64,iVBORw0..."
+            },
+            "secret": {
+              "type": "string",
+              "description": "The secret, in case user wants to manually enter it",
+              "example": "JBSWY3DPEHPK3PXP"
+            }
+          }
+        },
+        "Enable2FARequest": {
+          "type": "object",
+          "properties": {
+            "token": {
+              "type": "string",
+              "description": "token generated by the user's authenticator app",
+              "example": 123456
+            }
+          },
+          "required": [
+            "token"
+          ]
+        },
+        "Enable2FAResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Two-factor authentication enabled successfully."
+            }
+          }
+        },
+        "Enable2FAErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while enabling two-factor authentication."
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message if OTP verification fails",
+              "example": "Invalid OTP. Please try again."
+            }
+          }
+        },
+        "User": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The person's first name",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The person's last name",
+              "maxLength": 50
+            },
+            "birthDate": {
+              "type": "string",
+              "format": "date",
+              "description": "The person's birth date"
+            },
+            "nationalId": {
+              "type": "string",
+              "description": "National ID (9-digit SSN for US users)"
+            },
+            "countryOfIssue": {
+              "type": "string",
+              "description": "2-letter country code where the ID was issued",
+              "maxLength": 2
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The person's email address"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The person's address"
+                }
+              ]
+            }
+          },
+          "required": [
+            "firstName",
+            "lastName",
+            "birthDate",
+            "nationalId",
+            "countryOfIssue",
+            "email",
+            "address"
+          ]
+        },
+        "Document": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the document",
+              "example": "passport_image.png"
+            },
+            "type": {
+              "type": "string",
+              "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+              "example": "CERT_INC"
+            },
+            "side": {
+              "type": "string",
+              "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+              "example": "front, back"
+            },
+            "country": {
+              "type": "string",
+              "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+              "example": "USA",
+              "maxLength": 3
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "InitialUser": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The initial user of the company",
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "description": "This user's role at their company"
+                },
+                "walletAddress": {
+                  "type": "string",
+                  "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                },
+                "ipAddress": {
+                  "type": "string",
+                  "description": "The user's IP address"
+                },
+                "iovationBlackbox": {
+                  "type": "string",
+                  "description": "A blackbox string generated by the client side Iovation library"
+                }
+              },
+              "required": [
+                "iovationBlackbox",
+                "ipAddress",
+                "isTermsOfServiceAccepted"
+              ]
+            }
+          ]
+        },
+        "Address": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "line1": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "line2": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "city": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "region": {
+              "type": "string",
+              "maxLength": 60
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 15
+            },
+            "countryCode": {
+              "type": "string",
+              "maxLength": 2
+            },
+            "country": {
+              "type": "string",
+              "maxLength": 50
+            }
+          },
+          "required": [
+            "line1",
+            "city",
+            "region",
+            "postalCode",
+            "countryCode",
+            "country"
+          ]
+        },
+        "Entity": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Auto-generated UUID for the document",
+              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+            },
+            "name": {
+              "type": "string",
+              "description": "The legal entity's name"
+            },
+            "type": {
+              "type": "string",
+              "description": "The legal entity's type - LLC, S Corp, etc."
+            },
+            "description": {
+              "type": "string",
+              "description": "A brief description of the legal entity, and its activities"
+            },
+            "taxId": {
+              "type": "string",
+              "description": "The legal entity's national tax id"
+            },
+            "registrationNumber": {
+              "type": "string",
+              "description": "The legal entity's registration number"
+            },
+            "website": {
+              "type": "string",
+              "description": "The legal entity's website"
+            },
+            "expectedSpend": {
+              "type": "string",
+              "description": "How much the legal entity expects to spend each month"
+            },
+            "industry": {
+              "type": "string",
+              "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+            }
+          },
+          "required": [
+            "name",
+            "taxId",
+            "registrationNumber",
+            "website"
+          ]
+        },
+        "UserAddress": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "line2": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "region": {
+                  "type": "string",
+                  "maxLength": 60
+                },
+                "postalCode": {
+                  "type": "string",
+                  "maxLength": 15
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "region",
+                "postalCode",
+                "countryCode",
+                "country"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The person's address"
+            }
+          ]
+        },
+        "BusinessAddress": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "line2": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "region": {
+                  "type": "string",
+                  "maxLength": 60
+                },
+                "postalCode": {
+                  "type": "string",
+                  "maxLength": 15
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "region",
+                "postalCode",
+                "countryCode",
+                "country"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "The company's physical address"
+            }
+          ]
+        },
+        "ProfileUser": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name",
+                  "maxLength": 50
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name",
+                  "maxLength": 50
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The person's birth date"
+                },
+                "nationalId": {
+                  "type": "string",
+                  "description": "National ID (9-digit SSN for US users)"
+                },
+                "countryOfIssue": {
+                  "type": "string",
+                  "description": "2-letter country code where the ID was issued",
+                  "maxLength": 2
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "The person's email address"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The person's address"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "firstName",
+                "lastName",
+                "birthDate",
+                "nationalId",
+                "countryOfIssue",
+                "email",
+                "address"
+              ]
+            },
+            {
+              "type": "object",
+              "description": "This is the profile of the user"
+            }
+          ]
+        },
+        "ProfileCompany": {
+          "allOf": [
+            {
+              "type": "object",
+              "description": "This is the profile of the company",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            }
+          ]
+        },
+        "Profile": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "firstName": {
+                          "type": "string",
+                          "description": "The person's first name",
+                          "maxLength": 50
+                        },
+                        "lastName": {
+                          "type": "string",
+                          "description": "The person's last name",
+                          "maxLength": 50
+                        },
+                        "birthDate": {
+                          "type": "string",
+                          "format": "date",
+                          "description": "The person's birth date"
+                        },
+                        "nationalId": {
+                          "type": "string",
+                          "description": "National ID (9-digit SSN for US users)"
+                        },
+                        "countryOfIssue": {
+                          "type": "string",
+                          "description": "2-letter country code where the ID was issued",
+                          "maxLength": 2
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "The person's email address"
+                        },
+                        "address": {
+                          "allOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Auto-generated UUID for the document",
+                                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                },
+                                "line1": {
+                                  "type": "string",
+                                  "maxLength": 100
+                                },
+                                "line2": {
+                                  "type": "string",
+                                  "maxLength": 100
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "maxLength": 50
+                                },
+                                "region": {
+                                  "type": "string",
+                                  "maxLength": 60
+                                },
+                                "postalCode": {
+                                  "type": "string",
+                                  "maxLength": 15
+                                },
+                                "countryCode": {
+                                  "type": "string",
+                                  "maxLength": 2
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "maxLength": 50
+                                }
+                              },
+                              "required": [
+                                "line1",
+                                "city",
+                                "region",
+                                "postalCode",
+                                "countryCode",
+                                "country"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "description": "The person's address"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "firstName",
+                        "lastName",
+                        "birthDate",
+                        "nationalId",
+                        "countryOfIssue",
+                        "email",
+                        "address"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "This is the profile of the user"
+                    }
+                  ]
+                }
+              ]
+            },
+            "company": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "description": "This is the profile of the company",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The legal entity's name"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The legal entity's type - LLC, S Corp, etc."
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "A brief description of the legal entity, and its activities"
+                        },
+                        "taxId": {
+                          "type": "string",
+                          "description": "The legal entity's national tax id"
+                        },
+                        "registrationNumber": {
+                          "type": "string",
+                          "description": "The legal entity's registration number"
+                        },
+                        "website": {
+                          "type": "string",
+                          "description": "The legal entity's website"
+                        },
+                        "expectedSpend": {
+                          "type": "string",
+                          "description": "How much the legal entity expects to spend each month"
+                        },
+                        "industry": {
+                          "type": "string",
+                          "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "taxId",
+                        "registrationNumber",
+                        "website"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "user",
+            "company"
+          ]
+        },
+        "GetProfileResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Profile retrieved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique ID of the KYB draft.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the company.",
+              "example": "Acme Corp"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The company's physical address"
+                }
+              ]
+            },
+            "company": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            },
+            "documents": {
+              "type": "array",
+              "description": "List of KYB documents.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the document",
+                    "example": "passport_image.png"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                    "example": "CERT_INC"
+                  },
+                  "side": {
+                    "type": "string",
+                    "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                    "example": "front, back"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                    "example": "USA",
+                    "maxLength": 3
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            },
+            "representatives": {
+              "type": "array",
+              "description": "List of company representatives.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            },
+            "status": {
+              "type": "string",
+              "description": "The current status of the KYB process.",
+              "example": "Pending"
+            },
+            "ultimateBeneficialOwners": {
+              "type": "array",
+              "description": "List of the company's ultimate beneficial owners.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            }
+          }
+        },
+        "GetProfileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message for the failed profile retrieval.",
+              "example": "Error occurred while retrieving the profile."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information to assist in troubleshooting.",
+              "example": "Profile not found."
+            }
+          }
+        },
+        "UpdateProfileRequest": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "This is the profile of the user"
+                }
+              ]
+            },
+            "company": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "This is the profile of the company",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The legal entity's name"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The legal entity's type - LLC, S Corp, etc."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the legal entity, and its activities"
+                    },
+                    "taxId": {
+                      "type": "string",
+                      "description": "The legal entity's national tax id"
+                    },
+                    "registrationNumber": {
+                      "type": "string",
+                      "description": "The legal entity's registration number"
+                    },
+                    "website": {
+                      "type": "string",
+                      "description": "The legal entity's website"
+                    },
+                    "expectedSpend": {
+                      "type": "string",
+                      "description": "How much the legal entity expects to spend each month"
+                    },
+                    "industry": {
+                      "type": "string",
+                      "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "taxId",
+                    "registrationNumber",
+                    "website"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "UpdateProfileResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Profile updated successfully."
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "user": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "description": "The person's first name",
+                              "maxLength": 50
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "description": "The person's last name",
+                              "maxLength": 50
+                            },
+                            "birthDate": {
+                              "type": "string",
+                              "format": "date",
+                              "description": "The person's birth date"
+                            },
+                            "nationalId": {
+                              "type": "string",
+                              "description": "National ID (9-digit SSN for US users)"
+                            },
+                            "countryOfIssue": {
+                              "type": "string",
+                              "description": "2-letter country code where the ID was issued",
+                              "maxLength": 2
+                            },
+                            "email": {
+                              "type": "string",
+                              "format": "email",
+                              "description": "The person's email address"
+                            },
+                            "address": {
+                              "allOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "description": "Auto-generated UUID for the document",
+                                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                                    },
+                                    "line1": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "line2": {
+                                      "type": "string",
+                                      "maxLength": 100
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "maxLength": 60
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "maxLength": 15
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "maxLength": 2
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "maxLength": 50
+                                    }
+                                  },
+                                  "required": [
+                                    "line1",
+                                    "city",
+                                    "region",
+                                    "postalCode",
+                                    "countryCode",
+                                    "country"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "The person's address"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "firstName",
+                            "lastName",
+                            "birthDate",
+                            "nationalId",
+                            "countryOfIssue",
+                            "email",
+                            "address"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "This is the profile of the user"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "company": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "description": "This is the profile of the company",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "The legal entity's name"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "The legal entity's type - LLC, S Corp, etc."
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "A brief description of the legal entity, and its activities"
+                            },
+                            "taxId": {
+                              "type": "string",
+                              "description": "The legal entity's national tax id"
+                            },
+                            "registrationNumber": {
+                              "type": "string",
+                              "description": "The legal entity's registration number"
+                            },
+                            "website": {
+                              "type": "string",
+                              "description": "The legal entity's website"
+                            },
+                            "expectedSpend": {
+                              "type": "string",
+                              "description": "How much the legal entity expects to spend each month"
+                            },
+                            "industry": {
+                              "type": "string",
+                              "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "taxId",
+                            "registrationNumber",
+                            "website"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "user",
+                "company"
+              ]
+            }
+          }
+        },
+        "ProfileErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Error occurred while processing the profile request."
+            },
+            "error": {
+              "type": "string",
+              "example": "Invalid input or data not found."
+            }
+          }
+        },
+        "KYBFormRequest": {
+          "type": "object",
+          "properties": {
+            "initialUser": {
+              "type": "object",
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "description": "The person's first name",
+                      "maxLength": 50
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "The person's last name",
+                      "maxLength": 50
+                    },
+                    "birthDate": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "The person's birth date"
+                    },
+                    "nationalId": {
+                      "type": "string",
+                      "description": "National ID (9-digit SSN for US users)"
+                    },
+                    "countryOfIssue": {
+                      "type": "string",
+                      "description": "2-letter country code where the ID was issued",
+                      "maxLength": 2
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "description": "The person's email address"
+                    },
+                    "address": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "description": "Auto-generated UUID for the document",
+                              "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                            },
+                            "line1": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "line2": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "city": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "region": {
+                              "type": "string",
+                              "maxLength": 60
+                            },
+                            "postalCode": {
+                              "type": "string",
+                              "maxLength": 15
+                            },
+                            "countryCode": {
+                              "type": "string",
+                              "maxLength": 2
+                            },
+                            "country": {
+                              "type": "string",
+                              "maxLength": 50
+                            }
+                          },
+                          "required": [
+                            "line1",
+                            "city",
+                            "region",
+                            "postalCode",
+                            "countryCode",
+                            "country"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "description": "The person's address"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "firstName",
+                    "lastName",
+                    "birthDate",
+                    "nationalId",
+                    "countryOfIssue",
+                    "email",
+                    "address"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The initial user of the company",
+                  "properties": {
+                    "role": {
+                      "type": "string",
+                      "description": "This user's role at their company"
+                    },
+                    "walletAddress": {
+                      "type": "string",
+                      "description": "This user's wallet address; required if using a non-custodial solution, but not required otherwise"
+                    },
+                    "ipAddress": {
+                      "type": "string",
+                      "description": "The user's IP address"
+                    },
+                    "iovationBlackbox": {
+                      "type": "string",
+                      "description": "A blackbox string generated by the client side Iovation library"
+                    }
+                  },
+                  "required": [
+                    "iovationBlackbox",
+                    "ipAddress",
+                    "isTermsOfServiceAccepted"
+                  ]
+                }
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the company looking to create an account"
+            },
+            "address": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "line1": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "line2": {
+                      "type": "string",
+                      "maxLength": 100
+                    },
+                    "city": {
+                      "type": "string",
+                      "maxLength": 50
+                    },
+                    "region": {
+                      "type": "string",
+                      "maxLength": 60
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "maxLength": 15
+                    },
+                    "countryCode": {
+                      "type": "string",
+                      "maxLength": 2
+                    },
+                    "country": {
+                      "type": "string",
+                      "maxLength": 50
+                    }
+                  },
+                  "required": [
+                    "line1",
+                    "city",
+                    "region",
+                    "postalCode",
+                    "countryCode",
+                    "country"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "description": "The company's physical address"
+                }
+              ]
+            },
+            "chainId": {
+              "type": "string",
+              "description": "the chain id of the company's external collateral contract"
+            },
+            "contractAddress": {
+              "type": "string",
+              "description": "the address of the company's external collateral contract;"
+            },
+            "entity": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Auto-generated UUID for the document",
+                  "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The legal entity's name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The legal entity's type - LLC, S Corp, etc."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A brief description of the legal entity, and its activities"
+                },
+                "taxId": {
+                  "type": "string",
+                  "description": "The legal entity's national tax id"
+                },
+                "registrationNumber": {
+                  "type": "string",
+                  "description": "The legal entity's registration number"
+                },
+                "website": {
+                  "type": "string",
+                  "description": "The legal entity's website"
+                },
+                "expectedSpend": {
+                  "type": "string",
+                  "description": "How much the legal entity expects to spend each month"
+                },
+                "industry": {
+                  "type": "string",
+                  "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                }
+              },
+              "required": [
+                "name",
+                "taxId",
+                "registrationNumber",
+                "website"
+              ]
+            },
+            "representatives": {
+              "type": "array",
+              "description": "The company's representatives",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            },
+            "ultimateBeneficialOwners": {
+              "type": "array",
+              "description": "The company's ultimate beneficial owners",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Auto-generated UUID for the document",
+                    "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                  },
+                  "firstName": {
+                    "type": "string",
+                    "description": "The person's first name",
+                    "maxLength": 50
+                  },
+                  "lastName": {
+                    "type": "string",
+                    "description": "The person's last name",
+                    "maxLength": 50
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The person's birth date"
+                  },
+                  "nationalId": {
+                    "type": "string",
+                    "description": "National ID (9-digit SSN for US users)"
+                  },
+                  "countryOfIssue": {
+                    "type": "string",
+                    "description": "2-letter country code where the ID was issued",
+                    "maxLength": 2
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "The person's email address"
+                  },
+                  "address": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Auto-generated UUID for the document",
+                            "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "line2": {
+                            "type": "string",
+                            "maxLength": 100
+                          },
+                          "city": {
+                            "type": "string",
+                            "maxLength": 50
+                          },
+                          "region": {
+                            "type": "string",
+                            "maxLength": 60
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                          },
+                          "countryCode": {
+                            "type": "string",
+                            "maxLength": 2
+                          },
+                          "country": {
+                            "type": "string",
+                            "maxLength": 50
+                          }
+                        },
+                        "required": [
+                          "line1",
+                          "city",
+                          "region",
+                          "postalCode",
+                          "countryCode",
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "description": "The person's address"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "firstName",
+                  "lastName",
+                  "birthDate",
+                  "nationalId",
+                  "countryOfIssue",
+                  "email",
+                  "address"
+                ]
+              }
+            }
+          },
+          "required": [
+            "initialUser",
+            "name",
+            "address",
+            "entity",
+            "representatives",
+            "ultimateBeneficialOwners"
+          ]
+        },
+        "KYBFormResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Indicates the form is in draft mode.",
+              "example": "Pending",
+              "enum": [
+                "PENDING"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "description": "Message providing more information about the draft status.",
+              "example": "KYB information saved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique ID for tracking the draft submission.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO timestamp of the last update.",
+              "example": "2024-10-14T12:34:56Z"
+            }
+          }
+        },
+        "ErrorResponse": {
+          "type": "object",
+          "properties": {
+            "field": {
+              "type": "string",
+              "description": "The form field with the issue.",
+              "example": "businessName"
+            },
+            "message": {
+              "type": "string",
+              "description": "Description of the validation error.",
+              "example": "The business name is required."
+            }
+          }
+        },
+        "FormErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "General message about the validation error.",
+              "example": "Validation Failed"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "The form field with the issue.",
+                    "example": "businessName"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "Description of the validation error.",
+                    "example": "The business name is required."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYBResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "KYB information retrieved successfully."
+            },
+            "kybData": {
+              "type": "object",
+              "description": "The KYB information retrieved for the company.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "The unique ID of the KYB draft.",
+                  "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The name of the company.",
+                  "example": "Acme Corp"
+                },
+                "address": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Auto-generated UUID for the document",
+                          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "line2": {
+                          "type": "string",
+                          "maxLength": 100
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 50
+                        },
+                        "region": {
+                          "type": "string",
+                          "maxLength": 60
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "maxLength": 15
+                        },
+                        "countryCode": {
+                          "type": "string",
+                          "maxLength": 2
+                        },
+                        "country": {
+                          "type": "string",
+                          "maxLength": 50
+                        }
+                      },
+                      "required": [
+                        "line1",
+                        "city",
+                        "region",
+                        "postalCode",
+                        "countryCode",
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "description": "The company's physical address"
+                    }
+                  ]
+                },
+                "chainId": {
+                  "type": "string",
+                  "description": "the chain id of the company's external collateral contract"
+                },
+                "documents": {
+                  "type": "array",
+                  "description": "List of KYB documents.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the document",
+                        "example": "passport_image.png"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "Type of the document (e.g., CERT_INC, COMP_REG)",
+                        "example": "CERT_INC"
+                      },
+                      "side": {
+                        "type": "string",
+                        "description": "Side of the document, optional for CORPORATE documents and required for UBO documents",
+                        "example": "front, back"
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "Country of the document in ISO 3166-1 alpha-3 format (optional)",
+                        "example": "USA",
+                        "maxLength": 3
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "entity": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Auto-generated UUID for the document",
+                      "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The legal entity's name"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The legal entity's type - LLC, S Corp, etc."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "A brief description of the legal entity, and its activities"
+                    },
+                    "taxId": {
+                      "type": "string",
+                      "description": "The legal entity's national tax id"
+                    },
+                    "registrationNumber": {
+                      "type": "string",
+                      "description": "The legal entity's registration number"
+                    },
+                    "website": {
+                      "type": "string",
+                      "description": "The legal entity's website"
+                    },
+                    "expectedSpend": {
+                      "type": "string",
+                      "description": "How much the legal entity expects to spend each month"
+                    },
+                    "industry": {
+                      "type": "string",
+                      "description": "The legal entity's industry, e.g., \"Technology\", \"Finance\", etc."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "taxId",
+                    "registrationNumber",
+                    "website"
+                  ]
+                },
+                "representatives": {
+                  "type": "array",
+                  "description": "List of company representatives.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The person's first name",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The person's last name",
+                        "maxLength": 50
+                      },
+                      "birthDate": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "The person's birth date"
+                      },
+                      "nationalId": {
+                        "type": "string",
+                        "description": "National ID (9-digit SSN for US users)"
+                      },
+                      "countryOfIssue": {
+                        "type": "string",
+                        "description": "2-letter country code where the ID was issued",
+                        "maxLength": 2
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The person's email address"
+                      },
+                      "address": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "line2": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "city": {
+                                "type": "string",
+                                "maxLength": 50
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 60
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "maxLength": 15
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "maxLength": 2
+                              },
+                              "country": {
+                                "type": "string",
+                                "maxLength": 50
+                              }
+                            },
+                            "required": [
+                              "line1",
+                              "city",
+                              "region",
+                              "postalCode",
+                              "countryCode",
+                              "country"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "description": "The person's address"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName",
+                      "birthDate",
+                      "nationalId",
+                      "countryOfIssue",
+                      "email",
+                      "address"
+                    ]
+                  }
+                },
+                "ultimateBeneficialOwners": {
+                  "type": "array",
+                  "description": "List of the company's ultimate beneficial owners.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Auto-generated UUID for the document",
+                        "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "description": "The person's first name",
+                        "maxLength": 50
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "description": "The person's last name",
+                        "maxLength": 50
+                      },
+                      "birthDate": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "The person's birth date"
+                      },
+                      "nationalId": {
+                        "type": "string",
+                        "description": "National ID (9-digit SSN for US users)"
+                      },
+                      "countryOfIssue": {
+                        "type": "string",
+                        "description": "2-letter country code where the ID was issued",
+                        "maxLength": 2
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The person's email address"
+                      },
+                      "address": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "Auto-generated UUID for the document",
+                                "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+                              },
+                              "line1": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "line2": {
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "city": {
+                                "type": "string",
+                                "maxLength": 50
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 60
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "maxLength": 15
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "maxLength": 2
+                              },
+                              "country": {
+                                "type": "string",
+                                "maxLength": 50
+                              }
+                            },
+                            "required": [
+                              "line1",
+                              "city",
+                              "region",
+                              "postalCode",
+                              "countryCode",
+                              "country"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "description": "The person's address"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName",
+                      "birthDate",
+                      "nationalId",
+                      "countryOfIssue",
+                      "email",
+                      "address"
+                    ]
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "description": "The current status of the KYB process.",
+                  "example": "Pending"
+                },
+                "referralCode": {
+                  "type": "string",
+                  "example": "ABCD1234"
+                },
+                "referralCount": {
+                  "type": "number",
+                  "example": 10
+                }
+              }
+            }
+          }
+        },
+        "GetKYBErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message.",
+              "example": "Error occurred while retrieving KYB information."
+            },
+            "error": {
+              "type": "string",
+              "description": "A detailed error message for troubleshooting.",
+              "example": "KYB record not found."
+            }
+          }
+        },
+        "KYBStatusResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "example": "pending",
+              "enum": [
+                "notStarted",
+                "pending",
+                "pendingEmailVerification",
+                "emailVerified",
+                "saved",
+                "needsVerification",
+                "verificationPending",
+                "underReview",
+                "manualReview",
+                "needsInformation",
+                "verified",
+                "rejected",
+                "cancelled",
+                "denied",
+                "locked"
+              ]
+            }
+          }
+        },
+        "KYBStatusErrorResponse": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "example": "MISSING_INFORMATION"
+            },
+            "message": {
+              "type": "string",
+              "example": "Additional business details required."
+            }
+          }
+        },
+        "KYBSubmitResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A message providing more information about the submission.",
+              "example": "KYB form submitted successfully."
+            }
+          }
+        },
+        "IndividualUserAddress": {
+          "type": "object",
+          "properties": {
+            "line1": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "city": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "countryCode": {
+              "type": "string",
+              "maxLength": 2
+            },
+            "country": {
+              "type": "string",
+              "maxLength": 50
+            }
+          },
+          "required": [
+            "line1",
+            "city",
+            "countryCode",
+            "country"
+          ]
+        },
+        "IndividualUserRequest": {
+          "type": "object",
+          "properties": {
+            "firstName": {
+              "type": "string",
+              "description": "The customer's first name",
+              "example": "John",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The customer's last name",
+              "example": "Doe",
+              "maxLength": 50
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The customer's email address",
+              "example": "john.doe@example.com"
+            },
+            "birthDate": {
+              "type": "string",
+              "format": "date",
+              "description": "The person's birth date"
+            },
+            "address": {
+              "type": "object",
+              "properties": {
+                "line1": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                "countryCode": {
+                  "type": "string",
+                  "maxLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "line1",
+                "city",
+                "countryCode",
+                "country"
+              ]
+            },
+            "phoneCountryCode": {
+              "type": "string",
+              "description": "Customer country code",
+              "example": 91,
+              "maxLength": 3
+            },
+            "phoneNumber": {
+              "type": "string",
+              "description": "phoneNumber",
+              "example": 9999999999,
+              "maxLength": 15
+            },
+            "occupation": {
+              "type": "string",
+              "description": "occupation code fetched from master api",
+              "example": "11-3011",
+              "maxLength": 50
+            },
+            "annualSalary": {
+              "type": "number",
+              "description": "annualSalary",
+              "example": 4000000
+            },
+            "accountPurpose": {
+              "type": "string",
+              "description": "accountPurpose",
+              "example": "Investment",
+              "maxLength": 15
+            },
+            "expectedMonthlySpend": {
+              "type": "number",
+              "description": "expectedMonthlySpend",
+              "example": 10000
+            },
+            "walletAddress": {
+              "type": "string",
+              "description": "The person's wallet address; required if using the hosted completion flow and a non-custodial solution, but not required otherwise",
+              "example": "0x1234...abcd"
+            },
+            "isTermOfServiceAccepted": {
+              "type": "boolean",
+              "description": "is customer accepted all terms of service",
+              "example": true
+            },
+            "isWalletOwner": {
+              "type": "boolean",
+              "description": "is customer owner of wallet address",
+              "example": true
+            }
+          },
+          "required": [
+            "firstName",
+            "lastName",
+            "birthDate",
+            "walletAddress",
+            "address",
+            "ipAddress",
+            "isTermOfServiceAccepted"
+          ]
+        },
+        "KYCFormResponse": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Indicates the form is in draft mode.",
+              "example": "Pending",
+              "enum": [
+                "PENDING"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "description": "Message providing more information about the draft status.",
+              "example": "KYC application initiated successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique ID for tracking the draft submission.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO timestamp of the last update.",
+              "example": "2024-10-14T12:34:56Z"
+            },
+            "nextSteps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "verificationLink": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "example": "https://app-kyc.xyz/kyc"
+                      },
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                          },
+                          "redirect": {
+                            "type": "string",
+                            "format": "url",
+                            "example": "https://app-qa.pay.com/kycConfirmation"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "KYCErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Error message indicating the reason for failure",
+              "example": "Unable to initiate KYC because of the validation failures"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "The field that caused the validation error",
+                    "example": "walletAddress"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "The validation error message",
+                    "example": "walletAddress must be a valid address"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYCResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "KYC information retrieved successfully."
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The unique ID of the KYC draft.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "The first name of the individual user.",
+              "example": "John",
+              "maxLength": 50
+            },
+            "lastName": {
+              "type": "string",
+              "description": "The last name of the individual user.",
+              "example": "Doe",
+              "maxLength": 50
+            },
+            "createdOn": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The date and time when the user registers in the system.",
+              "example": "2024-10-14T12:34:56Z"
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The email address of the individual user.",
+              "example": "johndoe@johndoe.com"
+            },
+            "address": {
+              "type": "object",
+              "properties": {
+                "line1": {
+                  "type": "string",
+                  "description": "The first line of the address.",
+                  "example": "123, ABC Street",
+                  "maxLength": 100
+                },
+                "city": {
+                  "type": "string",
+                  "description": "The city of the address.",
+                  "example": "XYZ",
+                  "maxLength": 50
+                },
+                "countryCode": {
+                  "type": "string",
+                  "description": "The country code of the address.",
+                  "example": "IN",
+                  "maxLength": 2,
+                  "minLength": 2
+                },
+                "country": {
+                  "type": "string",
+                  "description": "The country of the address.",
+                  "example": "India",
+                  "maxLength": 50
+                }
+              }
+            },
+            "phoneCountryCode": {
+              "type": "string",
+              "description": "The country code of the phone number.",
+              "example": "91",
+              "maxLength": 3
+            },
+            "phoneNumber": {
+              "type": "string",
+              "description": "The phone number of the individual user.",
+              "example": "1234567890",
+              "maxLength": 15,
+              "minLength": 1
+            },
+            "badge": {
+              "type": "object",
+              "description": "Badge earned by the user based on their activities in the system.",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Short code for the badge.",
+                  "example": "SupF"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Full name of the badge.",
+                  "example": "SuperFan"
+                }
+              }
+            },
+            "referralCode": {
+              "type": "string",
+              "example": "ABCD1234"
+            },
+            "referralDiscount": {
+              "type": "number",
+              "description": "Discount value for the referral.",
+              "example": 0.1
+            },
+            "referralDiscountType": {
+              "type": "string",
+              "description": "Type of discount applied",
+              "example": "percentage",
+              "enum": [
+                "percentage",
+                "flat"
+              ]
+            },
+            "referralCount": {
+              "type": "number",
+              "example": 10
+            },
+            "referrerCode": {
+              "type": "string",
+              "example": "absdkfjhdsd"
+            },
+            "referrerDiscount": {
+              "type": "number",
+              "description": "Discount value for the referral.",
+              "example": 100
+            },
+            "referrerDiscountType": {
+              "type": "string",
+              "description": "Type of discount applied",
+              "example": "flat",
+              "enum": [
+                "percentage",
+                "flat"
+              ]
+            },
+            "walletAddress": {
+              "type": "string",
+              "description": "The wallet address of the individual user.",
+              "example": "0x1234567890abcdef1234567890abcdef12345678"
+            },
+            "nextSteps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "verificationLink": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "example": "https://app-kyc.xyz/kyc"
+                      },
+                      "params": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "example": "d195870c-4613-4fc2-ac2d-49d20ce145b3"
+                          },
+                          "redirect": {
+                            "type": "string",
+                            "format": "url",
+                            "example": "https://app-qa.pay.com/kycConfirmation"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "GetKYCErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A general error message.",
+              "example": "Error occurred while retrieving KYC information."
+            },
+            "error": {
+              "type": "string",
+              "description": "A detailed error message for troubleshooting.",
+              "example": "KYC record not found."
+            }
+          }
+        },
+        "MasterType": {
+          "type": "string",
+          "enum": [
+            "Country",
+            "DocumentType",
+            "DepositToken",
+            "CardStatus",
+            "UserRole",
+            "CardProduct",
+            "Consent"
+          ]
+        },
+        "MasterData": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "example": 1
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Country",
+                "DocumentType",
+                "DepositToken",
+                "CardStatus",
+                "UserRole",
+                "CardProduct",
+                "Consent"
+              ]
+            },
+            "key": {
+              "type": "string",
+              "example": "IN"
+            },
+            "value": {
+              "type": "string",
+              "example": "India"
+            },
+            "description": {
+              "type": "string",
+              "example": "Country in South Asia"
+            },
+            "isActive": {
+              "type": "boolean",
+              "example": true
+            }
+          }
+        },
+        "MasterDataResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A success message for the response.",
+              "example": "Master Data updated successfully"
+            },
+            "data": {
+              "type": "array",
+              "description": "List of naster data.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "example": 1
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Country",
+                      "DocumentType",
+                      "DepositToken",
+                      "CardStatus",
+                      "UserRole",
+                      "CardProduct",
+                      "Consent"
+                    ]
+                  },
+                  "key": {
+                    "type": "string",
+                    "example": "IN"
+                  },
+                  "value": {
+                    "type": "string",
+                    "example": "India"
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "Country in South Asia"
+                  },
+                  "isActive": {
+                    "type": "boolean",
+                    "example": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ConsumerOccupation": {
+          "type": "object",
+          "description": "Represents a consumer occupation entry.",
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Unique code identifier for the occupation.",
+              "example": "11-3011"
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the occupation.",
+              "example": "Administrative Services Managers"
+            },
+            "isActive": {
+              "type": "boolean",
+              "description": "Indicates if the occupation record is currently active.",
+              "example": true
+            }
+          },
+          "required": [
+            "code",
+            "name",
+            "isActive"
+          ]
+        },
+        "NotificationUpdateRequest": {
+          "type": "object",
+          "properties": {
+            "read": {
+              "type": "boolean",
+              "description": "Whether the notification is read or not",
+              "example": true
+            }
+          }
+        },
+        "NotificationResponse": {
+          "type": "object",
+          "properties": {
+            "notifications": {
+              "type": "array",
+              "description": "List of user notifications",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "example": 1
+                  },
+                  "message": {
+                    "type": "string",
+                    "example": "Your profile has been updated."
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2024-10-11T12:00:00Z"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "NotificationErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while fetching notifications."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Unable to retrieve notifications"
+            }
+          }
+        },
+        "CreatePasswordRequest": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "password"
+          ]
+        },
+        "CreatePasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Failed to create a password. Please ensure your token is valid and try again."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+              "example": "weak password"
+            }
+          }
+        },
+        "CreatePasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Success message",
+              "example": "Password created successfully. You can now sign in."
+            }
+          }
+        },
+        "ChangePasswordRequest": {
+          "type": "object",
+          "properties": {
+            "oldPassword": {
+              "type": "string",
+              "format": "password",
+              "description": "The user's current password",
+              "example": "oldpassword123"
+            },
+            "newPassword": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "oldPassword",
+            "newPassword"
+          ]
+        },
+        "ChangePasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password changed successfully."
+            }
+          }
+        },
+        "ChangePasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while changing password."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "Old password is incorrect"
+            }
+          }
+        },
+        "ForgotPasswordRequest": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "The user's registered email address",
+              "example": "user@example.com"
+            }
+          },
+          "required": [
+            "email"
+          ]
+        },
+        "ForgotPasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password reset link sent to your email."
+            }
+          }
+        },
+        "ForgotPasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Description of the error that occurred",
+              "example": "Error occurred while sending password reset link."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information (optional)",
+              "example": "User not found"
+            }
+          }
+        },
+        "ResetPasswordRequest": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string",
+              "format": "password",
+              "description": "The new password the user is creating. It should be at least 8 characters long and include a mix of uppercase, lowercase, numbers, and special characters for enhanced security.",
+              "example": "StrongP@ssw0rd123!"
+            }
+          },
+          "required": [
+            "password"
+          ]
+        },
+        "ResetPasswordResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message for the user",
+              "example": "Password reset successfully."
+            }
+          }
+        },
+        "ResetPasswordErrorResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "example": "Failed to create a password. Please ensure your token is valid and try again."
+            },
+            "error": {
+              "type": "string",
+              "description": "Detailed error information. This could indicate that password not meeting strength requirements.",
+              "example": "weak password"
+            }
+          }
+        },
+        "DocumentType": {
+          "type": "string",
+          "enum": [
+            "CERT_INC",
+            "COMP_REG",
+            "SH_REG",
+            "M_REG",
+            "PASSPORT",
+            "DL",
+            "NATIONALID"
+          ]
+        },
+        "DocumentSide": {
+          "type": "string",
+          "enum": [
+            "FRONT",
+            "BACK"
+          ]
+        },
+        "UploadRequest": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the document.",
+              "example": "passport.pdf"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "CERT_INC",
+                "COMP_REG",
+                "SH_REG",
+                "M_REG",
+                "PASSPORT",
+                "DL",
+                "NATIONALID"
+              ]
+            },
+            "side": {
+              "type": "string",
+              "enum": [
+                "FRONT",
+                "BACK"
+              ]
+            },
+            "country": {
+              "type": "string",
+              "description": "The country associated with the document.",
+              "example": "USA",
+              "maxLength": 3,
+              "minLength": 3
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "UploadResponse": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "A message about the success of the upload.",
+              "example": "Document uploaded successfully"
+            },
+            "documentId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The id of the uploaded file.",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        },
+        "UploadError": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "The HTTP status code.",
+              "example": 400
+            },
+            "error": {
+              "type": "string",
+              "description": "A short description of the error.",
+              "example": "Invalid file type"
+            },
+            "message": {
+              "type": "string",
+              "description": "A detailed message about the error.",
+              "example": "Only PDF, JPEG, JPG, and PNG file types are allowed."
+            }
+          }
+        }
+      },
+      "responses": {
+        "UnauthorizedError": {
+          "description": "Access is denied due to invalid or missing token.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Unauthorized access. Token is missing or invalid."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Invalid or expired token"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "InternalServerError": {
+          "description": "An unexpected error occurred on the server.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Something went wrong on the server. Please try again later."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Internal Server Error"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ForbiddenError": {
+          "description": "Token expired or not authorized.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "You are not authorized to access this resource. Please log in again."
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Forbidden"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "securitySchemes": {
+        "bearerAuth": {
+          "type": "http",
+          "scheme": "bearer",
+          "bearerFormat": "JWT"
+        },
+        "appKeyAuth": {
+          "type": "apiKey",
+          "name": "x-app-code",
+          "in": "header"
+        }
+      }
+    },
+    "security": [
+      {
+        "bearerAuth": []
+      },
+      {
+        "appKeyAuth": []
+      }
+    ],
+    "tags": [
+      {
+        "name": "Authentication",
+        "description": "Operations related to authentication"
+      },
+      {
+        "name": "Captcha",
+        "description": "Initializing and validating Geetest CAPTCHA challenges, used to verify human interaction on the frontend."
+      },
+      {
+        "name": "Password Management",
+        "description": "Operations related to user account password"
+      },
+      {
+        "name": "Two-Factor Authentication",
+        "description": "Operations related to two-factor authentication"
+      },
+      {
+        "name": "KYB",
+        "description": "Operations related to Corporate Customer Application"
+      },
+      {
+        "name": "KYC",
+        "description": "Operations related to Individual Customer Application"
+      },
+      {
+        "name": "Verification",
+        "description": "Operations related to KYB/KYC status"
+      },
+      {
+        "name": "Card Management",
+        "description": "Operations related to cards"
+      },
+      {
+        "name": "Master Management",
+        "description": "Operations related to master Data"
+      },
+      {
+        "name": "User Management",
+        "description": "Operations related to user Data"
+      },
+      {
+        "name": "Wallet",
+        "description": "Operations related to deposits"
+      },
+      {
+        "name": "Transactions",
+        "description": "Operations related to transactions"
+      }
+    ]
+  }

--- a/docs.json
+++ b/docs.json
@@ -25,9 +25,16 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "API",
+            "group": "API Consumer",
             "openapi": {
-              "source": "openapi.json",
+              "source": "api-reference/consumer.json",
+              "directory": "api-reference"
+            }
+          },
+          {
+            "group": "API Corporate",
+            "openapi": {
+              "source": "api-reference/corporate.json",
               "directory": "api-reference"
             }
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the API Reference tab by splitting the existing "API" group into two sections: "API Consumer" and "API Corporate," each with its own dedicated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->